### PR TITLE
Add Controller action: API::EventsController #past

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Api
+  class EventsController < ApplicationController
+    def past_get
+      events = Event.where('date < ?', DateTime.current).order(date: :desc)
+      render status: 200, json:  { data: events.as_json }
+    end
+  end
+end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -2,7 +2,7 @@
 
 module Api
   class EventsController < ApplicationController
-    def past_get
+    def past
       events = Event.where('date < ?', DateTime.current).order(date: :desc)
       render status: 200, json:  { data: events.as_json }
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,10 @@
 
 Rails.application.routes.draw do
   root 'site#home'
+
+  namespace :api do
+    namespace :events do
+      resources :past, only: [:past_get]
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,11 @@
 
 Rails.application.routes.draw do
   root 'site#home'
-
   namespace :api do
-    namespace :events do
-      resources :past, only: [:past_get]
+    resources :events, only: [:none] do
+      collection do
+        get 'past'
+      end
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -144,7 +144,7 @@ panel = Panel.create(
                Kerstin Puschke, Sylvia Fronczak, and Gabi Stefanini
                will answer YOUR questions about everything from CFPs,
                to making slides, to delivering technical talks!",
-  date: DateTime.new(2021, 8, 31, 16).utc
+  date: DateTime.new(2021, 7, 31, 16).utc
 )
 
 panel.speakers = [kerstin, gabi, sylvia]

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -3,12 +3,21 @@
 require './spec/rails_helper'
 
 RSpec.describe Api::EventsController, type: :controller do
-  describe 'GET #past_get' do
+  describe 'GET #past' do
+    before do
+      Meetup.create(title: 'Fake title', location: 'virtual', date: DateTime.now - 1.day)
+      Meetup.create(title: 'Fake title 2', location: 'virtual', date: DateTime.now - 2.weeks)
+      Panel.create(title: 'Fake title 3', location: 'Denver, Colorado', date: DateTime.now + 1.week)
+    end
+
     it 'correctly renders past events' do
       get :past
       expect(response).to have_http_status(200)
 
-      p JSON.parse(response.body)
+      body = JSON.parse(response.body)
+
+      expect(body['data'].count).to eq(2)
+      expect(body['data'].map { |item| item['title'] }).to eq(['Fake title', 'Fake title 2'])
     end
   end
 end

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require './spec/rails_helper'
+
+RSpec.describe Api::EventsController, type: :controller do
+  describe 'GET #past_get' do
+    it 'correctly renders past events' do
+      get :past
+      expect(response).to have_http_status(200)
+
+      p JSON.parse(response.body)
+    end
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/wnbrb/wnb-rb-site/issues/18

Some decisions that we made:
- Changed `#past_get` to `#past` as it felt more natural. But am open to change back to `past_get` if that's what is preferred
- We create Event objects, because there hasn't been a clear decision for Factory Bot vs. Fixtures. Could be something to add later
- Changed the seed so that the second 'event' reflects the description of a past event in July