### PR TITLE
add lang attribute to all html tags

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>WNB.rb</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>

--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>The page you were looking for doesn't exist (404)</title>
         <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/public/422.html
+++ b/public/422.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>The change you wanted was rejected (422)</title>
         <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/public/500.html
+++ b/public/500.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>We're sorry, but something went wrong (500)</title>
         <meta name="viewport" content="width=device-width,initial-scale=1" />


### PR DESCRIPTION
This PR addresses issue number 39
- Added `lang="en"` to all `html` tags with in the codebase
- Using `"en"` and not "en-US" as it is more widely recognized by screen readers