### PR TITLE
Fix link and style issues on Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'pg'
 gem 'puma', '~> 5.0'
 gem 'rails', '~> 6.1.4'
 gem 'sass-rails', '>= 6'
-gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 5.4.0'
 
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,9 +209,6 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.1.0)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -258,7 +255,6 @@ DEPENDENCIES
   sass-rails (>= 6)
   selenium-webdriver
   spring
-  turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)
   webdrivers

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,12 +4,10 @@
 // that code so it'll be compiled.
 
 import Rails from '@rails/ujs';
-import Turbolinks from 'turbolinks';
 import * as ActiveStorage from '@rails/activestorage';
 import 'channels';
 
 import '../stylesheets/application.scss';
 
 Rails.start();
-Turbolinks.start();
 ActiveStorage.start();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application' %>
+    <%= javascript_pack_tag 'application' %>
   </head>
 
   <body>

--- a/app/views/site/sponsor_us.html.erb
+++ b/app/views/site/sponsor_us.html.erb
@@ -1,2 +1,2 @@
 <%= javascript_pack_tag 'sponsor_us' %>
-<%= stylesheet_pack_tag "home_page" %>
+<%= stylesheet_pack_tag "sponsor_us" %>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
         "react-dom": "^17.0.2",
         "sass": "^1.32.7",
         "tailwindcss": "^2.2.16",
-        "turbolinks": "^5.2.0",
         "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9448,11 +9448,6 @@ tty-browserify@0.0.0:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
-
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"


### PR DESCRIPTION
Our Heroku deployment currently has a few issues:
1. The styles are messed up on the sponsorship page
2. When you click a link, it loads a blank page, and then the content only renders on reload.

I've done some research on both of these issues. It looks like issue 1 is due to incorrectly naming the stylesheet pack tag in the `sponsor_us` view, and the second issue can be remedied by removing Turbolinks (which we're not using anyway).  
[Here's the SO post that led me to believe this was a Turbolinks issue](https://stackoverflow.com/questions/25463144/ruby-on-rails-pages-are-initially-blank-but-load-properly-on-refresh).

I've tested this on a different Heroku deployment so as not to spam our actual server and these changes made it look the same as my local environment!

You can see these changes deployed here: https://testing-wnb.herokuapp.com

Here's what our actual deploy looks like currently 😁 
<img width="1440" alt="Screen Shot 2021-11-26 at 1 49 37 PM" src="https://user-images.githubusercontent.com/9601737/143621127-1b8e5c43-2520-455b-a118-b47e6b725270.png">
