### PR TITLE
Support user roles and introduce Pundit gem for authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 5.4.0'
 
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'pundit'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
+    pundit (2.1.1)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-mini-profiler (2.3.3)
@@ -277,6 +279,7 @@ DEPENDENCIES
   prettier (~> 2.0)
   pry-rails
   puma (~> 5.0)
+  pundit
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4)
   rexml (~> 3.2.5)

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Admin
   class EventsController < ApplicationController
+    before_action :authenticate_user!
+
     def index
       authorize Event
 

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Admin
+  class EventsController < ApplicationController
+    def index
+      authorize Event
+
+      # TODO: implement this method
+      render status: 200, json: {}
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,24 +1,34 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-    # Prevent CSRF attacks by raising an exception.
-    # For APIs, you may want to use :null_session instead.
-    protect_from_forgery with: :exception
-    before_action :configure_permitted_parameters, if: :devise_controller?
+  include Pundit
 
-    protected
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
-    def after_sign_in_path_for(_users)
-      admin_dashboard_path
-    end
+  rescue_from Pundit::NotAuthorizedError, with: :render_unauthorized
 
+  private
 
-    def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up) do |u|
- u.permit(:name, :email, :password, :password_confirmation, :remember_me) end
-      devise_parameter_sanitizer.permit(:sign_in) { |u| u.permit(:email, :password, :remember_me) }
-      devise_parameter_sanitizer.permit(:account_update) do |u|
- u.permit( :name, :email, :password, :password_confirmation, :current_password) end
-    end
-
+  def render_unauthorized
+    render status: 401, json: {}
   end
+
+  protected
+
+  def after_sign_in_path_for(_users)
+    admin_dashboard_path
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up) do |u|
+      u.permit(:name, :email, :password, :password_confirmation, :remember_me)
+    end
+    devise_parameter_sanitizer.permit(:sign_in) { |u| u.permit(:email, :password, :remember_me) }
+    devise_parameter_sanitizer.permit(:account_update) do |u|
+      u.permit(:name, :email, :password, :password_confirmation, :current_password)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  ADMIN = 'admin'
+  ROLES = [ADMIN].freeze
 
   ## TO-DO - add custom validation for email address ???
   validates :name, presence: true
   validates :email, uniqueness: true
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, authentication_keys: [:email]
+  validates :role, inclusion: { in: ROLES }, allow_nil: true
+  devise :database_authenticatable,
+         :registerable,
+         :recoverable,
+         :rememberable,
+         :validatable,
+         authentication_keys: [:email]
+
+  def admin?
+    role == ADMIN
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class EventPolicy < ApplicationPolicy
+  def index?
+    user.admin?
+  end
+
+  def show?
+    user.admin?
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+
+  def destroy?
+    user.admin?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-
-  devise_for :users, path: 'admin', path_names: { sign_in: '/', sign_up: 'new', registration: 'register' }
+  devise_for :users,
+             path: 'admin',
+             path_names: {
+               sign_in: '/',
+               sign_up: 'new',
+               registration: 'register',
+             }
   namespace :admin do
     get 'dashboard', to: 'dashboard#show'
   end
   get '/sponsor-us', to: 'site#sponsor_us'
-
 
   root 'site#home'
   namespace :api do
@@ -18,6 +22,11 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  namespace :admin do
+    resources :events, only: [:index]
+  end
+
   mount ActionCable.server => '/cable'
   resources :grid
 end

--- a/db/migrate/20211210204019_add_role_to_users.rb
+++ b/db/migrate/20211210204019_add_role_to_users.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddRoleToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_10_162416) do
+ActiveRecord::Schema.define(version: 2021_12_10_204019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2021_12_10_162416) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_11_012922) do
+ActiveRecord::Schema.define(version: 2021_12_10_204019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,16 @@ ActiveRecord::Schema.define(version: 2021_11_11_012922) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "jobs", force: :cascade do |t|
+    t.string "company"
+    t.string "title"
+    t.text "description"
+    t.string "link"
+    t.string "location"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "speakers", force: :cascade do |t|
     t.string "name"
     t.text "bio"
@@ -60,6 +70,7 @@ ActiveRecord::Schema.define(version: 2021_11_11_012922) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require './spec/rails_helper'
+
+RSpec.describe Admin::EventsController, type: :controller do
+  describe '#index' do
+    before { sign_in user }
+
+    context 'when user is not admin' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'returns 401' do
+        get :index
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    context 'when user is admin' do
+      let(:user) { FactoryBot.create(:user, role: User::ADMIN) }
+
+      it 'returns 200' do
+        get :index
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -4,10 +4,17 @@ require './spec/rails_helper'
 
 RSpec.describe Admin::EventsController, type: :controller do
   describe '#index' do
-    before { sign_in user }
+    context 'when user is not authenticated' do
+      it 'returns 302' do
+        get :index
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
 
     context 'when user is not admin' do
       let(:user) { FactoryBot.create(:user) }
+      before { sign_in user }
 
       it 'returns 401' do
         get :index
@@ -17,6 +24,7 @@ RSpec.describe Admin::EventsController, type: :controller do
 
     context 'when user is admin' do
       let(:user) { FactoryBot.create(:user, role: User::ADMIN) }
+      before { sign_in user }
 
       it 'returns 200' do
         get :index

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 FactoryBot.define do
-
   factory :user do
+    sequence(:email) { |n| "person#{n}@email.com" }
     sequence(:name) { |n| "Person #{n}" }
+    password { 'somepassword' }
   end
-
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,10 @@ RSpec.configure do |config|
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
+
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
 end


### PR DESCRIPTION
This PR introduces the concept of user roles and adds the [Pundit gem](https://github.com/varvet/pundit) to implement authorization in this app.

The next set of issues we want to tackle all involve creating endpoints that should only be accessed by admin users. To unblock this work, I wanted to ensure we had a system for authorizing users. Each user can now be assigned an "admin" role, and Pundit will check that the user is an admin before performing any of the actions in the `Admin::EventsController`.