### PR TITLE
Rename "Archive" to "Past Meetups"

### DIFF
--- a/app/javascript/components/layout/Footer.jsx
+++ b/app/javascript/components/layout/Footer.jsx
@@ -17,7 +17,7 @@ const Footer = () => (
                     Upcoming Meetup
                 </a>
                 <a className="footer-col-item" href="/meetups">
-                    Archive
+                    Past Meetups
                 </a>
                 <a className="footer-col-item" href="#">
                     Give a Talk

--- a/app/javascript/components/layout/Header.jsx
+++ b/app/javascript/components/layout/Header.jsx
@@ -61,7 +61,7 @@ const Header = () => {
                                     <a href="/">Upcoming Meetup</a>
                                 </li>
                                 <li>
-                                    <a href="/meetups">Archive</a>
+                                    <a href="/meetups">Past Meetups</a>
                                 </li>
                                 <li>
                                     <a href="/sponsor-us"> Sponsor Us</a>


### PR DESCRIPTION
Got some excellent feedback from @stefannibrasil that "Archive" is not very clear to non-native English speakers, so changing this to "Past Meetups" in the header and footer.

<img width="1179" alt="Screen Shot 2021-12-20 at 10 34 41 AM" src="https://user-images.githubusercontent.com/9601737/146792761-a68ecaa5-9c11-4c62-8e93-31f76981bdc1.png">

<img width="1166" alt="Screen Shot 2021-12-20 at 10 35 22 AM" src="https://user-images.githubusercontent.com/9601737/146792861-3ddd2f59-17ff-414d-942d-2a5460b1aae8.png">