### PR TITLE
Add admin events page

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -6,8 +6,8 @@ module Admin
     def index
       authorize Event
 
-      # TODO: implement this method
-      render status: 200, json: {}
+      @events = Event.includes(:speakers)
+                     .order(date: :desc)
     end
   end
 end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,0 +1,38 @@
+<div class="mt-3 ml-3">
+  <!-- TODO: Issue 22 - Add Create Event Page -->
+  <%= link_to 'Create new Event', '#' %>
+</div>
+
+<div class="m-3">
+  <table class="text-center">
+    <thead class="border-2">
+     <tr>
+        <th scope="col" class="p-3">Title</th>
+        <th scope="col" class="p-3">Type</th>
+        <th scope="col" class="p-3">Speakers</th>
+        <th scope="col" class="p-3">Date</th>
+        <th scope="col" class="p-3">Location</th>
+        <th scope="col" class="p-3">Description</th>
+        <th scope="col" class="p-3">Actions</th>
+     </tr>
+    </thead>
+    <tbody>
+      <% @events.each do |event| %>
+        <tr class="border-2">
+          <td class="p-3"><%= event.title %></td>
+          <td class="p-3"><%= event.type %></td>
+          <td class="p-3"><%= event.speakers.map(&:name).join(", ") %></td>
+          <td class="p-3"><%= event.date.strftime('%B %d, %Y %I:%M%p %:z') %></td>
+          <td class="p-3"><%= event.location %></td>
+          <td class="p-3"><%= event.description %></td>
+          <td class="p-3">
+            <!-- TODO: Issue 24 Add Edit Page -->
+            <%= link_to 'Edit', '#' %>
+            <!-- TODO: Issue 25 Add Delete Functionality -->
+            <%= link_to 'Delete', '#' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
This PR creates the admin events page (Issue https://github.com/wnbrb/wnb-rb-site/issues/23)
Co-authored with @jrussell416 

Notes: 
- This page includes _all events_ including both meetups and panels
- Added a few tailwind classes just for some basic styling
- Orders events in descending date order
- Adds placeholder links for add/edit/delete 

Questions/comments:
- Should the links be styled a particular way to look like buttons? Couldn't find an example of doing this anywhere else, but the issue does say they should be buttons.
- Any other information we should display or exclude from this page? Depending on the description length it might be a bit much for a table. We could truncate or exclude it if needed. 
- We may eventually want to paginate these events

![Screen Shot 2021-12-21 at 12 39 12 PM](https://user-images.githubusercontent.com/7715500/146981589-b46c3964-aac3-4bed-a221-cf0edb25f657.png)
