### PR TITLE
Update sponsorship page to match our one-pager

### DIFF
--- a/app/javascript/components/sponsor_us/AboutUsSection.jsx
+++ b/app/javascript/components/sponsor_us/AboutUsSection.jsx
@@ -4,14 +4,12 @@ const AboutUsSection = () => {
     return (
         <>
             <p className="m-2">
-                WNB.rb is a virtual community of over 200 women and non-binary Rubyists. It was
-                founded in 2021 by Jemma Issroff and Emily Giurleo with the goal of supporting a
-                more diverse group of people in making meaningful contributions to the Ruby world.
+                WNB.rb is a global community of women and non-binary Rubyists, ranging in experience
+                levels from recent bootcamp grads to CTOs.
             </p>
             <p className="m-2 pt-4">
-                WNB.rb initiatives include a monthly meetup featuring two technical speakers, a
-                thriving Slack discussion space, a job interview preparation group, regular panels
-                on rotating topics, a conference proposal working group, and more!
+                Our community-driven initiatives include a monthly meetup, an interview study group,
+                a conference proposal working group, a book club, and more!
             </p>
         </>
     );

--- a/app/javascript/components/sponsor_us/WhySponsorUsSection.jsx
+++ b/app/javascript/components/sponsor_us/WhySponsorUsSection.jsx
@@ -4,10 +4,9 @@ const WhySponsorUsSection = () => {
     return (
         <>
             <ul className="list-disc ml-10">
-                <li>Brand exposure to over 200 women and non-binary Rubyists.</li>
-                <li>Announcements about your company at WNB.rb events.</li>
-                <li>Post open positions in the #jobs channel on WNB.rb’s Slack.</li>
-                <li>Your company’s name and logo featured on the WNB.rb website.</li>
+                <li>Gain brand exposure to a rapidly growing community of 300+ Rubyists</li>
+                <li>Recruit women and non-binary Ruby developers via our jobs board</li>
+                <li>Contribute to making the Ruby community more welcoming and diverse</li>
             </ul>
             <p className="m-2 pt-4">
                 Have something else in mind? Please get in touch, and we’d be happy to discuss!,

--- a/app/javascript/components/sponsor_us/sponsorUsData.js
+++ b/app/javascript/components/sponsor_us/sponsorUsData.js
@@ -11,21 +11,30 @@ export const sponsorCardData = [
     {
         icon: Ruby,
         type: 'Ruby',
-        text: 'Provide books for all members of WNB.rb’s book club who would not otherwise be able to afford them.',
-        amount: '2,000',
+        text: 'Everything in Emerald Sponsorship and also sponsored events and tweets',
+        amount: '6,000',
     },
     {
         icon: Emerald,
         type: 'Emerald',
-        text: 'Compensate 6 months of women and non-binary speakers who give talks at our meetups.',
-        amount: '1,200',
+        text: 'Everything in Sapphire Sponsorship and also announcements at our events',
+        amount: '2,000',
     },
     {
         icon: Saphire,
         type: 'Saphire',
-        text: 'Pay for one year of Zoom pro, allowing WNB.rb members to host their own interview prep sessions, conference proposal workshops, and more!',
-        amount: '180',
+        text: 'Post on our jobs board, logo featured on our site',
+        amount: '1,000',
     },
+    /*
+     * TODO: Add Opal icon to add this section properly
+    {
+        icon: Opal,
+        type: 'Opal',
+        text: 'Pay for one year of Zoom pro, allowing WNB.rb members to host their own interview prep sessions, conference proposal workshops, and more!',
+        amount: '500',
+    },
+    */
 ];
 
 export const infoCardData = [


### PR DESCRIPTION
Needs a full design change here, just a temporary stop gap so it matches what the one pager says, and potential sponsors aren't confused by the mismatch
<img width="1039" alt="Screen Shot 2022-01-05 at 4 22 07 PM" src="https://user-images.githubusercontent.com/1988560/148291554-c3dd8b0c-4316-40d4-a44e-93f5c120c5c6.png">

