### PR TITLE
Add image_url to jobs table

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Job < ApplicationRecord
-  validates :company, :title, :description, :link, :location, presence: true
+  validates :company, :title, :description, :link, :location, :image_url, presence: true
 end

--- a/db/migrate/20220118025538_add_image_url_to_jobs.rb
+++ b/db/migrate/20220118025538_add_image_url_to_jobs.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddImageUrlToJobs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :jobs, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_10_204019) do
+ActiveRecord::Schema.define(version: 2022_01_18_025538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2021_12_10_204019) do
     t.string "location"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "image_url"
   end
 
   create_table "speakers", force: :cascade do |t|

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     description { 'Organize WNB.rb' }
     link { 'link-to-job.com' }
     location { 'Remote' }
+    image_url { 'aws.amazon.com/link-to-image.png' }
   end
 end


### PR DESCRIPTION
This PR adds a column called `image_url` to the `jobs` table. This allows us to specify an image link for each job posting. When a company sends us a job, we can upload their image to storage somewhere (AWS?) and then display it in each job posting.