### PR TITLE
Add speaker image url

### DIFF
--- a/app/javascript/components/pages/Meetups.jsx
+++ b/app/javascript/components/pages/Meetups.jsx
@@ -41,8 +41,13 @@ const Meetup = ({ speakers, title = '' }) => (
             <div className="w-full rounded shadow-lg border-t p-10 border-gray-100 overflow-hidden">
                 <h4 className="mb-4 text-xl font-bold text-gray md:text-2xl">{title}</h4>
                 {speakers.length > 0
-                    ? speakers.map(({ id, name, tagline }) => (
-                          <div key={id} className="flex align-start mb-4 text-lg">
+                    ? speakers.map(({ id, name, tagline, image_url }) => (
+                          <div key={id} className="flex content-center mb-8 text-lg">
+                              <img
+                                  className="object-cover w-14 h-14 mr-4 rounded-full"
+                                  src={image_url}
+                                  alt=""
+                              />
                               <div>
                                   <p className="font-bold text-gray md:text-lg">{name}</p>
                                   <p className="text-sm text-gray md:text-lg">{tagline}</p>

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -4,5 +4,5 @@ class Speaker < ApplicationRecord
   has_many :event_speakers, dependent: :destroy
   has_many :events, through: :event_speakers
 
-  validates :name, :bio, presence: true
+  validates :name, :bio, :image_url, presence: true
 end

--- a/config/initializers/rack.rb
+++ b/config/initializers/rack.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+Rack::MiniProfiler.config.position = 'bottom-right'

--- a/config/initializers/rack.rb
+++ b/config/initializers/rack.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-Rack::MiniProfiler.config.position = 'bottom-right'
+Rack::MiniProfiler.config.position = 'bottom-right' if Rails.env.development?

--- a/db/migrate/20220120180256_add_image_url_to_speakers.rb
+++ b/db/migrate/20220120180256_add_image_url_to_speakers.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddImageUrlToSpeakers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :speakers, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_10_204019) do
+ActiveRecord::Schema.define(version: 2022_01_20_180256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2021_12_10_204019) do
     t.string "tagline"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "image_url"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,7 @@ unless Rails.env.prod?
   Speaker.destroy_all
   EventSpeaker.destroy_all
   Event.destroy_all
+  User.destroy_all
 end
 
 p 'Create a meetup with two speakers'
@@ -22,7 +23,8 @@ jemma = Speaker.create(
   release of Letraset sheets containing Lorem Ipsum
   passages, and more recently with desktop publishing
   software like Aldus PageMaker including versions of Lorem
-  Ipsum."
+  Ipsum.",
+  image_url: 'https://picsum.photos/200/300'
 )
 
 stefanni = Speaker.create(
@@ -39,7 +41,8 @@ stefanni = Speaker.create(
         release of Letraset sheets containing Lorem Ipsum
         passages, and more recently with desktop publishing
         software like Aldus PageMaker including versions of Lorem
-        Ipsum."
+        Ipsum.",
+  image_url: 'https://picsum.photos/200'
 )
 
 meetup = Meetup.create(
@@ -126,7 +129,8 @@ kerstin = Speaker.create(
   release of Letraset sheets containing Lorem Ipsum
   passages, and more recently with desktop publishing
   software like Aldus PageMaker including versions of Lorem
-  Ipsum."
+  Ipsum.",
+  image_url: 'https://picsum.photos/300/200'
 )
 
 gabi = Speaker.create(
@@ -143,7 +147,8 @@ gabi = Speaker.create(
         release of Letraset sheets containing Lorem Ipsum
         passages, and more recently with desktop publishing
         software like Aldus PageMaker including versions of Lorem
-        Ipsum."
+        Ipsum.",
+  image_url: 'https://picsum.photos/300/200'
 )
 
 sylvia = Speaker.create(
@@ -160,7 +165,8 @@ sylvia = Speaker.create(
         release of Letraset sheets containing Lorem Ipsum
         passages, and more recently with desktop publishing
         software like Aldus PageMaker including versions of Lorem
-        Ipsum."
+        Ipsum.",
+  image_url: 'https://picsum.photos/300/200'
 )
 
 panel = Panel.create(

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::EventsController, type: :controller do
       Meetup.create(title: 'August Meetup', location: 'virtual', date: DateTime.new(2021, 8, 31, 16).utc)
       Panel.create(title: 'Future Panel', location: 'Denver, Colorado', date: DateTime.now + 1.week)
 
-      speaker = Speaker.create(name: 'Speaker Name', tagline: 'Software Developer', bio: 'Lorem Ipsum')
+      speaker = Speaker.create(name: 'Speaker Name', tagline: 'Software Developer', bio: 'Lorem Ipsum', image_url: 'https://picsum.photos/200')
       EventSpeaker.create( event: july_meetup, speaker: speaker, talk_title: 'Some talk title',
 talk_description: 'Lorem Ipsum')
     end


### PR DESCRIPTION
### Overview
This PR adds an `image_url` field to speakers and displays the image on the past meetups page  (Issue #58)
Co-authored by @lsaffel 

- [X] Create a new string field on the speakers table called image_url
- [X] Create a validation verifying that the image exists
- [X] Update the seeds to provide image URLs for the speakers generated there
- [X] On the past meetups page, render the speaker images

![Screen Shot 2022-01-20 at 12 48 55 PM](https://user-images.githubusercontent.com/7715500/150402816-317ba1d6-8e01-4825-87d6-a6f9a15590fb.png)

### Additional Change
Moved the rack-mini-profiler to the bottom right corner so that it was less in the way on admin pages
Example in top left:
![Screen Shot 2022-01-19 at 8 11 12 PM](https://user-images.githubusercontent.com/7715500/150402686-d1faf32b-fe42-426a-b302-99562591ed1c.png)
