### PR TITLE
Changes to Job Board

### DIFF
--- a/app/controllers/api/jobs_controller.rb
+++ b/app/controllers/api/jobs_controller.rb
@@ -8,7 +8,7 @@ module Api
       JWT.decode bearer_token, hmac_secret, true, { algorithm: 'HS256' }
 
       jobs = Job.all
-      render status: 200, json: { data: jobs.as_json }
+      render status: 200, json: { data: jobs.order(:sponsorship_level).as_json }
     rescue JWT::ExpiredSignature, JWT::DecodeError
       render status: 401, json: {}
     end

--- a/app/controllers/api/jobs_controller.rb
+++ b/app/controllers/api/jobs_controller.rb
@@ -8,7 +8,7 @@ module Api
       JWT.decode bearer_token, hmac_secret, true, { algorithm: 'HS256' }
 
       jobs = Job.all
-      render status: 200, json: { data: jobs.order(:sponsorship_level).as_json }
+      render status: 200, json: { data: jobs.order(sponsorship_level: :desc).as_json }
     rescue JWT::ExpiredSignature, JWT::DecodeError
       render status: 401, json: {}
     end

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -7,7 +7,6 @@ import Button from 'components/Button';
 import Card from 'components/Card';
 import Banner from 'components/Banner';
 import { getJobs } from '../../datasources';
-import { postedAtString } from '../../utils';
 import { UnauthorizedError } from '../../errors';
 
 import 'stylesheets/page';
@@ -68,7 +67,6 @@ const JobGroup = ({ jobs }) => {
                     imageUrl={job.image_url}
                     link={job.link}
                     location={job.location}
-                    createdAt={job.created_at}
                 />
             ))}
         </div>
@@ -92,7 +90,7 @@ const SponsorUsBanner = () => {
     );
 };
 
-const Job = ({ title, description, imageUrl, company, link, location, createdAt }) => {
+const Job = ({ title, description, imageUrl, company, link, location }) => {
     return (
         <Card className="mx-0 my-5 md:mr-8 max-w-[22rem]">
             <div className="flex flex-row">
@@ -110,7 +108,6 @@ const Job = ({ title, description, imageUrl, company, link, location, createdAt 
                         Apply
                     </a>
                 </Button>
-                <div>{`Posted ${postedAtString(createdAt)}`}</div>
             </div>
         </Card>
     );
@@ -125,5 +122,4 @@ Job.propTypes = {
     imageUrl: propTypes.string,
     link: propTypes.string,
     location: propTypes.string,
-    createdAt: propTypes.string,
 };

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Job < ApplicationRecord
-  SPONSORSHIP_LEVELS = { RUBY: 0, EMERALD: 1, SAPPHIRE: 2, OPAL: 3 }.freeze
+  SPONSORSHIP_LEVELS = { RUBY: 3, EMERALD: 2, SAPPHIRE: 1, OPAL: 0 }.freeze
 
   validates :company,
             :title,

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Job < ApplicationRecord
-  SPONSORSHIP_LEVELS = { RUBY: 3, EMERALD: 2, SAPPHIRE: 1, OPAL: 0 }.freeze
+  enum sponsorship_level: %i[opal sapphire emerald ruby], _suffix: true
 
   validates :company,
             :title,
@@ -11,8 +11,6 @@ class Job < ApplicationRecord
             :image_url,
             :sponsorship_level,
             presence: true
-
-  validates :sponsorship_level, inclusion: { in: SPONSORSHIP_LEVELS.values }
 
   def as_json
     {

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
 class Job < ApplicationRecord
-  validates :company, :title, :description, :link, :location, :image_url, presence: true
+  SPONSORSHIP_LEVELS = { RUBY: 0, EMERALD: 1, SAPPHIRE: 2, OPAL: 3 }.freeze
+
+  validates :company,
+            :title,
+            :description,
+            :link,
+            :location,
+            :image_url,
+            :sponsorship_level,
+            presence: true
+
+  validates :sponsorship_level, inclusion: { in: SPONSORSHIP_LEVELS.values }
+
+  def as_json
+    {
+      id: id,
+      title: title,
+      company: company,
+      description: description,
+      location: location,
+      link: link,
+      image_url: image_url,
+    }
+  end
 end

--- a/db/migrate/20220129221831_add_sponsorship_level_to_jobs.rb
+++ b/db/migrate/20220129221831_add_sponsorship_level_to_jobs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSponsorshipLevelToJobs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :jobs, :sponsorship_level, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_20_180256) do
+ActiveRecord::Schema.define(version: 2022_01_29_221831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2022_01_20_180256) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "image_url"
+    t.integer "sponsorship_level"
   end
 
   create_table "speakers", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -220,6 +220,7 @@ Job.create!(
     'Help organize WNB.rb, a community for women and non-binary Rubyists!
     Responsibilities include organizing and supporting underrepresented developers.',
   image_url: 'https://picsum.photos/200',
+  sponsorship_level: 0,
 )
 
 Job.create!(
@@ -233,6 +234,7 @@ Job.create!(
     having a direct imapct on eradicating those pesky Jedi knights!',
   image_url: 'https://picsum.photos/200',
   created_at: Time.now - 2.weeks,
+  sponsorship_level: 3,
 )
 
 Job.create!(
@@ -245,6 +247,7 @@ Job.create!(
     pouring beer and don\'t mind the occasional wraith stopping by.',
   image_url: 'https://picsum.photos/200',
   created_at: Time.now - 1.month,
+  sponsorship_level: 2,
 )
 
 Job.create!(
@@ -258,4 +261,5 @@ Job.create!(
     Pokemon, to understand the power that\'s inside.',
   image_url: 'https://picsum.photos/200',
   created_at: Time.now - 3.months,
+  sponsorship_level: 1,
 )

--- a/spec/controllers/api/jobs_controller_spec.rb
+++ b/spec/controllers/api/jobs_controller_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe Api::JobsController, type: :controller do
             location: 'Remote',
           }.stringify_keys,
         )
+        expect(body['data'].first).not_to have_key('sponsorship_level')
       end
     end
   end

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     link { 'link-to-job.com' }
     location { 'Remote' }
     image_url { 'https://picsum.photos/200' }
+    sponsorship_level { 0 }
   end
 end


### PR DESCRIPTION
This PR implements a couple of pretty small changes to the job board functionality and appearance

### 1. Ordering jobs by sponsorship level of company

The first thing this PR does is order the jobs on the job board based on the sponsorship level of the companies that have posted them. Companies at higher sponsorship levels have their jobs come first.

To accomplish this, I:
* Added a `sponsorship_level` column to the jobs table
* On the backend, ordered jobs by the `sponsorship_level` column
* Changed the `as_json` functionality so sponsorship levels are not revealed to the frontend (this isn't strictly necessary, but I don't want to share this info if a company doesn't want it to be shared)

### 2. Removing the "posted at" date from the job listings

@jemmaissroff pointed out that this could make older listings seem outdated, even if they're not, so I've removed part of the UI.