### PR TITLE
Past meetup page

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -18,7 +18,7 @@ module Api
       event_date = DateTime.new(params[:year].to_i, params[:month].to_i)
       event = Event.where(date: event_date..event_date.end_of_month).first
       if event.present?
-        render status: 200, json: { data: event.as_json }
+        render status: 200, json: { data: event.as_json(include: :speakers) }
       else
         render status: 404, json: { data: 'No events found' }
       end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -12,4 +12,6 @@ class SiteController < ApplicationController
   def jobs_authenticate; end
 
   def donate; end
+  
+  def past_meetup; end
 end

--- a/app/javascript/components/SpeakersList.jsx
+++ b/app/javascript/components/SpeakersList.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SpeakersList = ({ speakers }) => {
+    if (speakers?.length > 0) {
+        return speakers.map(({ id, name, tagline, image_url }) => (
+            <div key={id} className="flex content-center mb-8 text-lg">
+                <img className="object-cover w-14 h-14 mr-4 rounded-full" src={image_url} alt="" />
+                <div>
+                    <p className="font-bold text-gray md:text-lg">{name}</p>
+                    <p className="text-sm text-gray md:text-lg">{tagline}</p>
+                </div>
+            </div>
+        ));
+    } else {
+        return null;
+    }
+};
+
+SpeakersList.propTypes = {
+    speakers: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default SpeakersList;

--- a/app/javascript/components/icons/Microphone.jsx
+++ b/app/javascript/components/icons/Microphone.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Microphone = ({ className }) => (
+    <svg
+        className={className}
+        width="17"
+        height="18"
+        viewBox="0 0 17 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M8.5 2C9.603 2 10.5 2.897 10.5 4V11C10.5 12.103 9.603 13 8.5 13C7.397 13 6.5 12.103 6.5 11V4C6.5 2.897 7.397 2 8.5 2ZM8.5 0C6.291 0 4.5 1.791 4.5 4V11C4.5 13.209 6.291 15 8.5 15C10.709 15 12.5 13.209 12.5 11V4C12.5 1.791 10.709 0 8.5 0ZM16.5 9V11C16.5 15.418 12.918 19 8.5 19C4.082 19 0.5 15.418 0.5 11V9H2.5V11C2.5 14.309 5.191 17 8.5 17C11.809 17 14.5 14.309 14.5 11V9H16.5ZM9.5 22V20H7.5V22H3.5V24H13.5V22H9.5Z"
+            fill="#F27C7A"
+        />
+    </svg>
+);
+
+Microphone.propTypes = {
+    className: PropTypes.string,
+};
+
+export default Microphone;

--- a/app/javascript/components/layout/Footer.jsx
+++ b/app/javascript/components/layout/Footer.jsx
@@ -49,6 +49,9 @@ const Footer = () => (
                 <a className="footer-col-item" href="/jobs">
                     Job Board
                 </a>
+                <a className="footer-col-item" href="/meetups">
+                    Past Meetups
+                </a>
             </div>
         </div>
 

--- a/app/javascript/components/layout/Header.jsx
+++ b/app/javascript/components/layout/Header.jsx
@@ -58,6 +58,9 @@ const Header = () => {
                                     <a href="/jobs">Job Board</a>
                                 </li>
                                 <li>
+                                    <a href="/meetups">Past Meetups</a>
+                                </li>
+                                <li>
                                     <a href="/sponsor-us"> Sponsor Us</a>
                                 </li>
                             </ul>

--- a/app/javascript/components/pages/Meetups.jsx
+++ b/app/javascript/components/pages/Meetups.jsx
@@ -125,6 +125,8 @@ const Meetups = () => {
                                                           date,
                                                           event_speakers,
                                                       }) => {
+                                                          const numericMonth =
+                                                              new Date(date).getMonth() + 1;
                                                           return (
                                                               <Meetup
                                                                   key={id}
@@ -134,7 +136,7 @@ const Meetups = () => {
                                                                   year={new Date(date)
                                                                       .getFullYear()
                                                                       .toString()}
-                                                                  month={month
+                                                                  month={numericMonth
                                                                       .toString()
                                                                       .padStart(2, '0')}
                                                               />

--- a/app/javascript/components/pages/Meetups.jsx
+++ b/app/javascript/components/pages/Meetups.jsx
@@ -36,7 +36,7 @@ MonthSection.propTypes = {
     children: PropTypes.node,
 };
 
-const Meetup = ({ speakers, title = '', event_speakers }) => {
+const Meetup = ({ speakers, title = '', event_speakers, year, month }) => {
     const eventWithSpeaker = event_speakers.map((talk) => {
         const speaker = speakers.find((speak) => speak.id === talk.speaker_id);
         return { ...talk, speaker };
@@ -71,9 +71,11 @@ const Meetup = ({ speakers, title = '', event_speakers }) => {
                         ))}
                 </div>
                 <div className="bg-gray-200 text-right">
-                    <button className="my-4 mr-6 py-4 px-8 bg-gray-600 rounded text-white text-lg md:text-xl">
-                        View
-                    </button>
+                    <a href={`/meetups/${year}/${month}`}>
+                        <button className="my-4 mr-6 py-4 px-8 bg-gray-600 rounded text-white text-lg md:text-xl">
+                            View
+                        </button>
+                    </a>
                 </div>
             </div>
         </li>
@@ -84,6 +86,8 @@ Meetup.propTypes = {
     speakers: PropTypes.array,
     title: PropTypes.string,
     event_speakers: PropTypes.array,
+    year: PropTypes.string,
+    month: PropTypes.string,
 };
 
 const Meetups = () => {
@@ -114,13 +118,25 @@ const Meetups = () => {
                                           return (
                                               <MonthSection key={month} month={month}>
                                                   {meetups.map(
-                                                      ({ id, speakers, title, event_speakers }) => {
+                                                      ({
+                                                          id,
+                                                          speakers,
+                                                          title,
+                                                          date,
+                                                          event_speakers,
+                                                      }) => {
                                                           return (
                                                               <Meetup
                                                                   key={id}
                                                                   speakers={speakers}
                                                                   title={title}
                                                                   event_speakers={event_speakers}
+                                                                  year={new Date(date)
+                                                                      .getFullYear()
+                                                                      .toString()}
+                                                                  month={month
+                                                                      .toString()
+                                                                      .padStart(2, '0')}
                                                               />
                                                           );
                                                       },

--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -67,7 +67,7 @@ const PastMeetup = () => {
     return (
         <SharedLayout>
             <div className="max-w-[73rem] px-10 md:px-0 mx-auto my-10 sm:my-20">
-                <PageTitleWithContainer text={`${monthName} ${year} meetup`} />
+                <PageTitleWithContainer text={`${monthName} ${year} Meetup`} />
             </div>
             <div className="container flex mx-auto md:max-w-[50rem] lg:max-w-[73rem]">
                 {loading ? (
@@ -75,7 +75,7 @@ const PastMeetup = () => {
                 ) : (
                     <div className="container mx-20">
                         <VideoBlock videoUrl={videoUrl} title={title} />
-                        <div className="w-full rounded shadow-lg border-t p-10 border-gray-100 overflow-hidden">
+                        <div className="w-full rounded border-t p-10 border-gray-100 overflow-hidden">
                             <h3 className="text-2xl font-bold mx-2 my-2">{title}</h3>
                             <SpeakersList speakers={speakers} />
                             <p className="m-2 pt-4">{description}</p>

--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { getPastMeetup } from '../../datasources';
+import SharedLayout from 'components/layout/SharedLayout';
+import PageTitle from 'components/PageTitle';
+import 'stylesheets/page';
+import 'stylesheets/meetup';
+
+const PastMeetup = () => {
+    const [meetup, setMeetup] = useState({});
+
+    useEffect(() => {
+        const fetchData = async () => {
+            const data = await getPastMeetup();
+            setMeetup(data);
+        };
+
+        fetchData();
+    }, []);
+
+    console.log('data', meetup);
+    const { title, description, speakers, panel_video_link: videoUrl } = meetup;
+    return (
+        <SharedLayout>
+            <PageTitle text="YEAR HERE MONTH HERE MEETUP" />
+            <iframe
+                width="560"
+                height="315"
+                src={videoUrl}
+                title="YouTube video player"
+                frameBorder="0"
+            ></iframe>
+            <h1>{title}</h1>;
+            <div className="w-full rounded shadow-lg border-t p-10 border-gray-100 overflow-hidden">
+                <h4 className="mb-4 text-xl font-bold text-gray md:text-2xl">{title}</h4>
+                {speakers?.length > 0
+                    ? speakers.map(({ id, name, tagline }) => (
+                          <div key={id} className="flex align-start mb-4 text-lg">
+                              <div>
+                                  <p className="font-bold text-gray md:text-lg">{name}</p>
+                                  <p className="text-sm text-gray md:text-lg">{tagline}</p>
+                              </div>
+                          </div>
+                      ))
+                    : null}
+            </div>
+            <h2>{description}</h2>
+            <h1>About the speakers</h1>
+            {speakers?.map(({ id, bio }) => (
+                <div key={id}>{bio}</div>
+            ))}
+        </SharedLayout>
+    );
+};
+
+export default PastMeetup;

--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -5,6 +5,7 @@ import SharedLayout from 'components/layout/SharedLayout';
 import PageTitleWithContainer from 'components/PageTitle';
 import SpeakersList from '../SpeakersList';
 import Microphone from '../icons/Microphone';
+import LoadingSpinner from 'components/LoadingSpinner';
 import 'stylesheets/page';
 import 'stylesheets/meetup';
 
@@ -27,11 +28,11 @@ VideoBlock.propTypes = {
 const SpeakerBiosBlock = ({ speakers }) => {
     return (
         <div className="container max-w-2xl my-8 mx-3 p-4 flex flex-col">
-            <div className="inline-flex items-center gap-2 align-center">
+            <div className="inline-flex items-center gap-2 align-center mb-5">
                 <Microphone />
                 <h4 className="text-xl font-bold text-gray md:text-2xl">About the speakers</h4>
             </div>
-            <div className="flex items-center gap-20">
+            <div className="flex flex-wrap items-center gap-5">
                 {speakers?.map(({ id, bio }) => (
                     <div key={id}>{bio}</div>
                 ))}
@@ -49,12 +50,14 @@ const PastMeetup = () => {
     const month = window.month;
     const eventDate = new Date(Date.UTC(year, Number(month) - 1));
     const monthName = eventDate.toLocaleDateString('en-US', { month: 'long' });
+    const [loading, setLoading] = useState(true);
     const [meetup, setMeetup] = useState({});
 
     useEffect(() => {
         const fetchData = async () => {
             const data = await getPastMeetup(year, month);
             setMeetup(data);
+            setLoading(false);
         };
 
         fetchData();
@@ -65,10 +68,12 @@ const PastMeetup = () => {
         <SharedLayout>
             <div className="max-w-[73rem] px-10 md:px-0 mx-auto my-10 sm:my-20">
                 <PageTitleWithContainer text={`${monthName} ${year} meetup`} />
-                {meetup == 'No events found' ? (
-                    <h3 className="text-2xl font-bold mx-2 my-2">No events found for this month</h3>
+            </div>
+            <div className="container flex mx-auto md:max-w-[50rem] lg:max-w-[73rem]">
+                {loading ? (
+                    <LoadingSpinner />
                 ) : (
-                    <>
+                    <div className="container mx-20">
                         <VideoBlock videoUrl={videoUrl} title={title} />
                         <div className="w-full rounded shadow-lg border-t p-10 border-gray-100 overflow-hidden">
                             <h3 className="text-2xl font-bold mx-2 my-2">{title}</h3>
@@ -78,7 +83,7 @@ const PastMeetup = () => {
                         <div className="flex flex-col items-center bg-gray-100">
                             <SpeakerBiosBlock speakers={speakers} />
                         </div>
-                    </>
+                    </div>
                 )}
             </div>
         </SharedLayout>

--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -4,38 +4,38 @@ import { getPastMeetup } from '../../datasources';
 import SharedLayout from 'components/layout/SharedLayout';
 import PageTitleWithContainer from 'components/PageTitle';
 import SpeakersList from '../SpeakersList';
+import Microphone from '../icons/Microphone';
 import 'stylesheets/page';
 import 'stylesheets/meetup';
 
-const VideoBlock = ({ videoUrl }) => {
+const VideoBlock = ({ videoUrl, title }) => {
     if (!videoUrl) {
-        return <p className="m-2 pt-4">No video yet</p>;
+        return null;
     }
     return (
-        <div className="card-container flex flex-wrap justify-center">
-            <iframe
-                width="560"
-                height="315"
-                src={videoUrl}
-                title="YouTube video player"
-                frameBorder="0"
-            ></iframe>
+        <div className="card-container flex flex-wrap justify-center aspect-w-16 aspect-h-9">
+            <iframe src={videoUrl} title={title} frameBorder="0"></iframe>;
         </div>
     );
 };
 
 VideoBlock.propTypes = {
     videoUrl: PropTypes.string,
+    title: PropTypes.string,
 };
 
-// TODO: How to get the microphone icon in?
 const SpeakerBiosBlock = ({ speakers }) => {
     return (
-        <div className="bg-gray-200 card-container flex flex-wrap justify-center p-10">
-            <h4 className="mb-4 text-xl font-bold text-gray md:text-2xl">About the speakers</h4>
-            {speakers?.map(({ id, bio }) => (
-                <div key={id}>{bio}</div>
-            ))}
+        <div className="container max-w-2xl my-8 mx-3 p-4 flex flex-col">
+            <div className="inline-flex items-center gap-2 align-center">
+                <Microphone />
+                <h4 className="text-xl font-bold text-gray md:text-2xl">About the speakers</h4>
+            </div>
+            <div className="flex items-center gap-20">
+                {speakers?.map(({ id, bio }) => (
+                    <div key={id}>{bio}</div>
+                ))}
+            </div>
         </div>
     );
 };
@@ -45,35 +45,42 @@ SpeakerBiosBlock.propTypes = {
 };
 
 const PastMeetup = () => {
+    const year = window.year;
+    const month = window.month;
+    const eventDate = new Date(Date.UTC(year, Number(month) - 1));
+    const monthName = eventDate.toLocaleDateString('en-US', { month: 'long' });
     const [meetup, setMeetup] = useState({});
 
     useEffect(() => {
         const fetchData = async () => {
-            const data = await getPastMeetup();
+            const data = await getPastMeetup(year, month);
             setMeetup(data);
         };
 
         fetchData();
-    }, []);
+    }, [year, month]);
 
-    console.log('data', meetup);
     const { title, description, speakers, panel_video_link: videoUrl } = meetup;
     return (
         <SharedLayout>
-            <PageTitleWithContainer text="July 2021 meetup" />
-            {meetup == 'No events found' ? (
-                <p className="m-2 pt-4">No events found for this month</p>
-            ) : (
-                <>
-                    <VideoBlock videoUrl={videoUrl} />
-                    <div className="w-full rounded shadow-lg border-t p-10 border-gray-100 overflow-hidden">
-                        <h3 className="text-2xl font-bold mx-2 my-2">{title}</h3>
-                        <SpeakersList speakers={speakers} />
-                        <p className="m-2 pt-4">{description}</p>
-                    </div>
-                    <SpeakerBiosBlock speakers={speakers} />
-                </>
-            )}
+            <div className="max-w-[73rem] px-10 md:px-0 mx-auto my-10 sm:my-20">
+                <PageTitleWithContainer text={`${monthName} ${year} meetup`} />
+                {meetup == 'No events found' ? (
+                    <h3 className="text-2xl font-bold mx-2 my-2">No events found for this month</h3>
+                ) : (
+                    <>
+                        <VideoBlock videoUrl={videoUrl} title={title} />
+                        <div className="w-full rounded shadow-lg border-t p-10 border-gray-100 overflow-hidden">
+                            <h3 className="text-2xl font-bold mx-2 my-2">{title}</h3>
+                            <SpeakersList speakers={speakers} />
+                            <p className="m-2 pt-4">{description}</p>
+                        </div>
+                        <div className="flex flex-col items-center bg-gray-100">
+                            <SpeakerBiosBlock speakers={speakers} />
+                        </div>
+                    </>
+                )}
+            </div>
         </SharedLayout>
     );
 };

--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -2,9 +2,47 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getPastMeetup } from '../../datasources';
 import SharedLayout from 'components/layout/SharedLayout';
-import PageTitle from 'components/PageTitle';
+import PageTitleWithContainer from 'components/PageTitle';
+import SpeakersList from '../SpeakersList';
 import 'stylesheets/page';
 import 'stylesheets/meetup';
+
+const VideoBlock = ({ videoUrl }) => {
+    if (!videoUrl) {
+        return <p className="m-2 pt-4">No video yet</p>;
+    }
+    return (
+        <div className="card-container flex flex-wrap justify-center">
+            <iframe
+                width="560"
+                height="315"
+                src={videoUrl}
+                title="YouTube video player"
+                frameBorder="0"
+            ></iframe>
+        </div>
+    );
+};
+
+VideoBlock.propTypes = {
+    videoUrl: PropTypes.string,
+};
+
+// TODO: How to get the microphone icon in?
+const SpeakerBiosBlock = ({ speakers }) => {
+    return (
+        <div className="bg-gray-200 card-container flex flex-wrap justify-center p-10">
+            <h4 className="mb-4 text-xl font-bold text-gray md:text-2xl">About the speakers</h4>
+            {speakers?.map(({ id, bio }) => (
+                <div key={id}>{bio}</div>
+            ))}
+        </div>
+    );
+};
+
+SpeakerBiosBlock.propTypes = {
+    speakers: PropTypes.arrayOf(PropTypes.object),
+};
 
 const PastMeetup = () => {
     const [meetup, setMeetup] = useState({});
@@ -22,33 +60,20 @@ const PastMeetup = () => {
     const { title, description, speakers, panel_video_link: videoUrl } = meetup;
     return (
         <SharedLayout>
-            <PageTitle text="YEAR HERE MONTH HERE MEETUP" />
-            <iframe
-                width="560"
-                height="315"
-                src={videoUrl}
-                title="YouTube video player"
-                frameBorder="0"
-            ></iframe>
-            <h1>{title}</h1>;
-            <div className="w-full rounded shadow-lg border-t p-10 border-gray-100 overflow-hidden">
-                <h4 className="mb-4 text-xl font-bold text-gray md:text-2xl">{title}</h4>
-                {speakers?.length > 0
-                    ? speakers.map(({ id, name, tagline }) => (
-                          <div key={id} className="flex align-start mb-4 text-lg">
-                              <div>
-                                  <p className="font-bold text-gray md:text-lg">{name}</p>
-                                  <p className="text-sm text-gray md:text-lg">{tagline}</p>
-                              </div>
-                          </div>
-                      ))
-                    : null}
-            </div>
-            <h2>{description}</h2>
-            <h1>About the speakers</h1>
-            {speakers?.map(({ id, bio }) => (
-                <div key={id}>{bio}</div>
-            ))}
+            <PageTitleWithContainer text="July 2021 meetup" />
+            {meetup == 'No events found' ? (
+                <p className="m-2 pt-4">No events found for this month</p>
+            ) : (
+                <>
+                    <VideoBlock videoUrl={videoUrl} />
+                    <div className="w-full rounded shadow-lg border-t p-10 border-gray-100 overflow-hidden">
+                        <h3 className="text-2xl font-bold mx-2 my-2">{title}</h3>
+                        <SpeakersList speakers={speakers} />
+                        <p className="m-2 pt-4">{description}</p>
+                    </div>
+                    <SpeakerBiosBlock speakers={speakers} />
+                </>
+            )}
         </SharedLayout>
     );
 };

--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -48,7 +48,7 @@ SpeakerBiosBlock.propTypes = {
 const PastMeetup = () => {
     const year = window.year;
     const month = window.month;
-    const eventDate = new Date(Date.UTC(year, Number(month) - 1));
+    const eventDate = new Date(year, Number(month - 1));
     const monthName = eventDate.toLocaleDateString('en-US', { month: 'long' });
     const [loading, setLoading] = useState(true);
     const [meetup, setMeetup] = useState({});

--- a/app/javascript/datasources/index.js
+++ b/app/javascript/datasources/index.js
@@ -74,3 +74,9 @@ const productionDonationAmounts = [
     { value: 500, link: 'https://buy.stripe.com/4gw3cSexj38u44o7sA' },
     { value: 1000, link: 'https://buy.stripe.com/8wMeVAbl710mdEY009' },
 ];
+
+export const getPastMeetup = async () => {
+    const result = await fetch(`${API_ROOT}/events/2021/07`);
+    const json = await result.json();
+    return json.data;
+};

--- a/app/javascript/datasources/index.js
+++ b/app/javascript/datasources/index.js
@@ -75,8 +75,8 @@ const productionDonationAmounts = [
     { value: 1000, link: 'https://buy.stripe.com/8wMeVAbl710mdEY009' },
 ];
 
-export const getPastMeetup = async () => {
-    const result = await fetch(`${API_ROOT}/events/2021/07`);
+export const getPastMeetup = async (year, month) => {
+    const result = await fetch(`${API_ROOT}/events/${year}/${month}`);
     const json = await result.json();
     return json.data;
 };

--- a/app/javascript/packs/past_meetup.jsx
+++ b/app/javascript/packs/past_meetup.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PastMeetup from '../components/pages/PastMeetup';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const body = document.createElement('div');
+    body.style = 'min-height: 100vh';
+
+    ReactDOM.render(<PastMeetup />, document.body.appendChild(body));
+});

--- a/app/views/site/past_meetup.erb
+++ b/app/views/site/past_meetup.erb
@@ -1,2 +1,6 @@
 <%= javascript_pack_tag 'past_meetup' %>
 <%= stylesheet_pack_tag "past_meetup" %>
+<%= javascript_tag do %>
+  var year = <%= raw(params[:year]) %>
+  var month = <%= raw(params[:month]) %>
+<% end %>

--- a/app/views/site/past_meetup.erb
+++ b/app/views/site/past_meetup.erb
@@ -1,0 +1,2 @@
+<%= javascript_pack_tag 'past_meetup' %>
+<%= stylesheet_pack_tag "past_meetup" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get '/jobs', to: 'site#jobs'
   get '/jobs/authenticate', to: 'site#jobs_authenticate'
   get '/donate', to: 'site#donate'
+  get '/past-meetup', to: 'site#past_meetup'
 
   root 'site#home'
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   get '/jobs', to: 'site#jobs'
   get '/jobs/authenticate', to: 'site#jobs_authenticate'
   get '/donate', to: 'site#donate'
-  get '/past-meetup', to: 'site#past_meetup'
+  get '/meetups/:year/:month', to: 'site#past_meetup'
 
   root 'site#home'
   namespace :api do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,7 +55,7 @@ meetup =
     title: 'August 2021 Meetup',
     description: 'Our meetup in August',
     date: DateTime.new(2021, 8, 31, 16).utc,
-    panel_video_link: "https://www.youtube.com/embed/n43O0u77d8o",
+    panel_video_link: 'https://www.youtube.com/embed/n43O0u77d8o',
   )
 
 EventSpeaker.create(
@@ -103,7 +103,7 @@ meetup2 =
     title: 'July 2021 Meetup',
     description: 'Our meetup in July',
     date: DateTime.new(2021, 7, 31, 16).utc,
-    panel_video_link: "https://www.youtube.com/embed/GlpZPv1bp4g",
+    panel_video_link: 'https://www.youtube.com/embed/GlpZPv1bp4g',
   )
 
 EventSpeaker.create(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,6 +55,7 @@ meetup =
     title: 'August 2021 Meetup',
     description: 'Our meetup in August',
     date: DateTime.new(2021, 8, 31, 16).utc,
+    panel_video_link: "https://www.youtube.com/embed/n43O0u77d8o",
   )
 
 EventSpeaker.create(
@@ -102,6 +103,7 @@ meetup2 =
     title: 'July 2021 Meetup',
     description: 'Our meetup in July',
     date: DateTime.new(2021, 7, 31, 16).utc,
+    panel_video_link: "https://www.youtube.com/embed/GlpZPv1bp4g",
   )
 
 EventSpeaker.create(


### PR DESCRIPTION
Adds a past meetup page, Issue #7
- [x] Works for both past panels and past meetups.
- [x] It should have one or more videos from the event, along with a title, description, and speaker info.
Displays the video from the `panel_video_link` on an event.  I'm not sure how more than one video per event would be stored as this field doesn't seem to be an array?  But please let me know if I've misunderstood.

- [x] The speaker bios can be put at a section on the bottom.
In the design these are in two columns, but I found this didn't work very well when there were more than 2 speakers, so I've used the speaker listing from the design for the Upcoming Meetup (single column).  Happy to change if this isn't ok!

- [x] This page should be linked from the cards on the /meetups page
- [x] The /meetups page should be added back to the header and footer as "Past Meetups" 