### PR TITLE
Fix the code of conduct link on the homepage

### DIFF
--- a/app/javascript/components/home/ExceedYourProfessionalGoalsSection.jsx
+++ b/app/javascript/components/home/ExceedYourProfessionalGoalsSection.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 const ExceedYourProfessionalGoalsSection = () => {
     return (
-        <>
+        <p>
             Use our #jobs channel on Slack to find your next opportunity. Join our CFP working group
             to have experienced speakers review your conference proposal. Learn new technical skills
             at our meetup, and level up in your career. With support from the WNB.rb community, you
             can set more abitious goals than ever before!
-        </>
+        </p>
     );
 };
 export default ExceedYourProfessionalGoalsSection;

--- a/app/javascript/components/home/GiveSupportSection.jsx
+++ b/app/javascript/components/home/GiveSupportSection.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 const GiveSupportSection = () => {
     return (
-        <>
+        <p>
             Whether you’re looking to mentor others or be mentored yourself, WNB.rb is ready for
             you! Post in our #advice channel to get the perspective of someone who’s been in your
             shoes, or jump into the #ruby-questions channel to help someone struggling with a
             technical problem.
-        </>
+        </p>
     );
 };
 export default GiveSupportSection;

--- a/app/javascript/components/home/JoinOurWelcomingCommunitySection.jsx
+++ b/app/javascript/components/home/JoinOurWelcomingCommunitySection.jsx
@@ -9,7 +9,7 @@ const JoinOurWelcomingCommunitySection = () => {
             <a href="https://tinyurl.com/wnb-rb-coc" target="_blank" rel="noopener noreferrer">
                 code of conduct
             </a>{' '}
-            to to prevent gatekeeping and other unsavory behavior.
+            to prevent gatekeeping and other unsavory behavior.
         </p>
     );
 };

--- a/app/javascript/components/home/JoinOurWelcomingCommunitySection.jsx
+++ b/app/javascript/components/home/JoinOurWelcomingCommunitySection.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 
 const JoinOurWelcomingCommunitySection = () => {
     return (
-        <>
+        <p>
             Attend our monthly meetup or start up a conversation in Slack to begin interacting with
             our community of over 350 women and non-binary Rubyists. Here at WNB.rb, we value safety
-            above all else; that is why we have a code of conduct [LINK] to to prevent gatekeeping
-            and other unsavory behavior.
-        </>
+            above all else; that is why we have a{' '}
+            <a href="https://tinyurl.com/wnb-rb-coc" target="_blank" rel="noopener noreferrer">
+                code of conduct
+            </a>{' '}
+            to to prevent gatekeeping and other unsavory behavior.
+        </p>
     );
 };
 

--- a/app/javascript/stylesheets/page.css
+++ b/app/javascript/stylesheets/page.css
@@ -14,3 +14,7 @@ body {
     flex-direction: column;
     min-height: 100vh;
 }
+
+p a {
+    @apply underline;
+}


### PR DESCRIPTION
We forgot to actually link the code of conduct on the home page 😆 This PR fixes that.

## Before:
<img width="802" alt="Screen Shot 2022-02-15 at 7 25 43 PM" src="https://user-images.githubusercontent.com/9601737/154172801-dc663a8f-70e6-4af9-85ac-065bf87498a9.png">

## After:
<img width="774" alt="Screen Shot 2022-02-15 at 7 27 46 PM" src="https://user-images.githubusercontent.com/9601737/154172998-8dde0020-3c13-423b-866d-1321b4b1b44b.png">