### PR TITLE
Add API endpoint for upcoming event

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -24,7 +24,7 @@ module Api
       end
     end
 
-    def upcoming_event
+    def upcoming
       events = Event.where('date > ?', DateTime.current).order(date: :asc)
       events_by_date =
         events

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -4,20 +4,39 @@ module Api
   class EventsController < ApplicationController
     def past
       events = Event.where('date < ?', DateTime.current).order(date: :desc)
-      events_by_date = events.group_by { |event| event.date.year }.transform_values do |events_by_year|
-        events_by_year.group_by { |event| event.date.strftime('%B') }  # group by month name
-      end
+      events_by_date =
+        events
+          .group_by { |event| event.date.year }
+          .transform_values do |events_by_year|
+            events_by_year.group_by { |event| event.date.strftime('%B') } # group by month name
+          end
 
-      render status: 200, json:  { data: events_by_date.as_json(include: :speakers) }
+      render status: 200, json: { data: events_by_date.as_json(include: :speakers) }
     end
 
     def past_by_month
       event_date = DateTime.new(params[:year].to_i, params[:month].to_i)
       event = Event.where(date: event_date..event_date.end_of_month).first
       if event.present?
-        render status: 200, json: {data: event.as_json}
+        render status: 200, json: { data: event.as_json }
       else
-        render status: 404, json: {data: 'No events found'}
+        render status: 404, json: { data: 'No events found' }
+      end
+    end
+
+    def upcoming_event
+      events = Event.where('date > ?', DateTime.current).order(date: :asc)
+      events_by_date =
+        events
+          .group_by { |event| event.date.year }
+          .transform_values do |events_by_year|
+            events_by_year.group_by { |event| event.date.strftime('%B') }
+          end
+
+      if events.present?
+        render status: 200, json: { data: events_by_date.as_json(include: :speakers) }
+      else
+        render status: 404, json: { data: 'No events found' }
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
       collection do
         get 'past'
         get '/:year/:month', to: 'events#past_by_month'
-        get 'upcoming_event'
+        get 'upcoming'
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
       collection do
         get 'past'
         get '/:year/:month', to: 'events#past_by_month'
+        get 'upcoming_event'
       end
     end
 

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -3,19 +3,36 @@
 require './spec/rails_helper'
 
 RSpec.describe Api::EventsController, type: :controller do
-  before do
-    Meetup.destroy_all
-  end
+  before { Meetup.destroy_all }
 
   describe 'GET #past' do
     before do
-      july_meetup = Meetup.create(title: 'July Meetup', location: 'virtual', date: DateTime.new(2021, 7, 31, 16).utc)
-      Meetup.create(title: 'August Meetup', location: 'virtual', date: DateTime.new(2021, 8, 31, 16).utc)
+      july_meetup =
+        Meetup.create(
+          title: 'July Meetup',
+          location: 'virtual',
+          date: DateTime.new(2021, 7, 31, 16).utc,
+        )
+      Meetup.create(
+        title: 'August Meetup',
+        location: 'virtual',
+        date: DateTime.new(2021, 8, 31, 16).utc,
+      )
       Panel.create(title: 'Future Panel', location: 'Denver, Colorado', date: DateTime.now + 1.week)
 
-      speaker = Speaker.create(name: 'Speaker Name', tagline: 'Software Developer', bio: 'Lorem Ipsum', image_url: 'https://picsum.photos/200')
-      EventSpeaker.create( event: july_meetup, speaker: speaker, talk_title: 'Some talk title',
-talk_description: 'Lorem Ipsum')
+      speaker =
+        Speaker.create(
+          name: 'Speaker Name',
+          tagline: 'Software Developer',
+          bio: 'Lorem Ipsum',
+          image_url: 'https://picsum.photos/200',
+        )
+      EventSpeaker.create(
+        event: july_meetup,
+        speaker: speaker,
+        talk_title: 'Some talk title',
+        talk_description: 'Lorem Ipsum',
+      )
     end
 
     it 'correctly gets past events' do
@@ -51,15 +68,72 @@ talk_description: 'Lorem Ipsum')
     end
 
     it 'returns one event for a given month' do
-      get :past_by_month, params: {year: '2021', month: '8'}
+      get :past_by_month, params: { year: '2021', month: '8' }
       expect(response).to have_http_status(200)
       body = JSON.parse(response.body)
       expect(body['data']['title']).to eq('August event')
     end
 
     it 'returns a 404 when no event exists for that month' do
-      get :past_by_month, params: {year: '2021', month: '11'}
+      get :past_by_month, params: { year: '2021', month: '11' }
       expect(response).to have_http_status(404)
+    end
+  end
+
+  describe 'GET #upcoming_event' do
+    before do
+      august_meetup =
+        Meetup.create(
+          title: 'August Meetup',
+          location: 'virtual',
+          date: DateTime.new(2022, 8, 31, 16).utc,
+        )
+      Meetup.create(
+        title: 'September Meetup',
+        location: 'virtual',
+        date: DateTime.new(2022, 9, 25, 16).utc,
+      )
+      Panel.create(title: 'Future Panel', location: 'Denver, Colorado', date: DateTime.now - 1.week)
+
+      speaker =
+        Speaker.create(
+          name: 'Speaker Name',
+          tagline: 'Software Developer',
+          bio: 'Lorem Ipsum',
+          image_url: 'https://picsum.photos/200',
+        )
+      EventSpeaker.create(
+        event: august_meetup,
+        speaker: speaker,
+        talk_title: 'Some talk title',
+        talk_description: 'Lorem Ipsum',
+      )
+    end
+
+    it 'correctly gets upcoming events' do
+      get :upcoming_event
+      expect(response).to have_http_status(200)
+
+      body = JSON.parse(response.body)
+      expect(body['data']['2022'].count).to eq(2)
+    end
+
+    it 'renders events by year and month' do
+      get :upcoming_event
+      body = JSON.parse(response.body)
+      august_meetup = body['data']['2022']['August'].first
+      expect(august_meetup['title']).to eq('August Meetup')
+
+      september_meetup = body['data']['2022']['September'].first
+      expect(september_meetup['title']).to eq('September Meetup')
+    end
+
+    it 'includes speaker data' do
+      get :upcoming_event
+      body = JSON.parse(response.body)
+
+      august_meetup = body['data']['2022']['August'].first
+      expect(august_meetup['speakers'].first['name']).to eq('Speaker Name')
     end
   end
 end

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Api::EventsController, type: :controller do
     end
   end
 
-  describe 'GET #upcoming_event' do
+  describe 'GET #upcoming' do
     before do
       august_meetup =
         Meetup.create(
@@ -111,7 +111,7 @@ RSpec.describe Api::EventsController, type: :controller do
     end
 
     it 'correctly gets upcoming events' do
-      get :upcoming_event
+      get :upcoming
       expect(response).to have_http_status(200)
 
       body = JSON.parse(response.body)
@@ -119,7 +119,7 @@ RSpec.describe Api::EventsController, type: :controller do
     end
 
     it 'renders events by year and month' do
-      get :upcoming_event
+      get :upcoming
       body = JSON.parse(response.body)
       august_meetup = body['data']['2022']['August'].first
       expect(august_meetup['title']).to eq('August Meetup')
@@ -129,7 +129,7 @@ RSpec.describe Api::EventsController, type: :controller do
     end
 
     it 'includes speaker data' do
-      get :upcoming_event
+      get :upcoming
       body = JSON.parse(response.body)
 
       august_meetup = body['data']['2022']['August'].first


### PR DESCRIPTION
This PR is to add an API endpoint and the according routes returning a JSON response to get the upcoming meetup into the api/events_controller

- [x] Add an API endpoint in api/events_controler 
- [x] Add routes
- [x] Add Test to api/events_controller spec

**Acceptance Criteria**

in the console create a new meetup with a speaker
```
august_meetup = Meetup.create(title: 'August Meetup', location: 'virtual', date: DateTime.new(2022, 8, 31, 16).utc)
speaker = Speaker.create(name: 'Speaker Name', tagline: 'Software Developer', bio: 'Lorem Ipsum', image_url: 'https://picsum.photos/200')
EventSpeaker.create(event: august_meetup, speaker: speaker, talk_title: 'Some talk title', talk_description: 'Lorem Ipsum')
```

Run Forman with `forman start`
Go to the url `http://localhost:5000/api/events/upcoming`

![Capture d’écran 2022-03-15 à 12 04 41](https://user-images.githubusercontent.com/43042737/158364459-30092fe4-87e5-4de9-8809-da2db0664d71.png)



Ilafont & dsouza worked on Issue #19 
Closes #19 