### PR TITLE
Only run job board digest task on Mondays

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test do
   gem 'capybara', '>= 3.26'
   gem 'factory_bot_rails'
   gem 'selenium-webdriver'
+  gem 'timecop'
   gem 'webdrivers'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,7 @@ GEM
     strscan (3.0.1)
     thor (1.2.1)
     tilt (2.0.10)
+    timecop (0.9.5)
     timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -350,6 +351,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   selenium-webdriver
   slack-ruby-client
+  timecop
   tzinfo-data
   web-console (>= 4.1.0)
   webdrivers

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module WnbRbSite
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Eastern Time (US & Canada)'
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/lib/tasks/job_board.rake
+++ b/lib/tasks/job_board.rake
@@ -6,7 +6,7 @@ namespace :job_board do
     # The free Heroku scheduler cannot be set to run on a specific day of the week.
     # If we only want jobs to be posted to Slack on Mondays, we need to specify
     # that here.
-    next unless is_monday?
+    next unless Date.today.monday?
 
     slack_client = SlackClient.new
     jobs_channel_id = ENV['SLACK_JOBS_CHANNEL']
@@ -17,11 +17,5 @@ namespace :job_board do
     HEREDOC
 
     slack_client.message_channel(recipient_id: jobs_channel_id, text: text)
-  end
-
-  private
-
-  def is_monday?
-    DateTime.now.strftime('%A') == 'Monday'
   end
 end

--- a/lib/tasks/job_board.rake
+++ b/lib/tasks/job_board.rake
@@ -3,16 +3,25 @@
 namespace :job_board do
   desc 'Send digest of current posted jobs to Slack'
   task digest: :environment do
+    # The free Heroku scheduler cannot be set to run on a specific day of the week.
+    # If we only want jobs to be posted to Slack on Mondays, we need to specify
+    # that here.
+    next unless is_monday?
+
     slack_client = SlackClient.new
     jobs_channel_id = ENV['SLACK_JOBS_CHANNEL']
     jobs = Job.last(10)
     text = <<~HEREDOC
       Check out the most recent jobs listed on our <https://www.wnb-rb.dev/jobs|job board>! Password: #{ENV['JOB_BOARD_PASSWORD']}
-      #{jobs.map do |job|
-        "\n - #{job.title} at #{job.company}"
-      end.join}
+      #{jobs.map { |job| "\n - #{job.title} at #{job.company}" }.join}
     HEREDOC
 
     slack_client.message_channel(recipient_id: jobs_channel_id, text: text)
+  end
+
+  private
+
+  def is_monday?
+    DateTime.now.strftime('%A') == 'Monday'
   end
 end

--- a/spec/tasks/job_board/digest_spec.rb
+++ b/spec/tasks/job_board/digest_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe 'job_board:digest' do
   after(:each) { Rake::Task['job_board:digest'].reenable }
 
   context 'when it is Monday' do
-    # April 11, 2022 was a Monday
-    before { Timecop.travel(Time.new(2022, 4, 11)) }
+    before { Timecop.travel(Date.today.last_week(:monday)) }
     after { Timecop.return }
 
     it 'posts job listings to Slack' do
@@ -24,8 +23,7 @@ RSpec.describe 'job_board:digest' do
   end
 
   context 'when it is not Monday' do
-    # April 12, 2022 was a Tuesday
-    before { Timecop.travel(Time.new(2022, 4, 12)) }
+    before { Timecop.travel(Date.today.last_week(:tuesday)) }
     after { Timecop.return }
 
     it 'does not post job listings to Slack' do

--- a/spec/tasks/job_board/digest_spec.rb
+++ b/spec/tasks/job_board/digest_spec.rb
@@ -5,18 +5,35 @@ require 'rails_helper'
 Rails.application.load_tasks
 
 RSpec.describe 'job_board:digest' do
-  after(:each) do
-    Rake::Task['job_board:digest'].reenable
+  after(:each) { Rake::Task['job_board:digest'].reenable }
+
+  context 'when it is Monday' do
+    # April 11, 2022 was a Monday
+    before { Timecop.travel(Time.new(2022, 4, 11)) }
+    after { Timecop.return }
+
+    it 'posts job listings to Slack' do
+      client = stub_slack_client
+      job = create(:job)
+      Rake::Task['job_board:digest'].invoke
+
+      expect(client).to have_received(:message_channel).with(
+        hash_including(text: /- #{job.title} at #{job.company}/),
+      )
+    end
   end
 
-  it 'posts job listings to Slack' do
-    client = stub_slack_client
-    job = create(:job)
-    Rake::Task['job_board:digest'].invoke
+  context 'when it is not Monday' do
+    # April 12, 2022 was a Tuesday
+    before { Timecop.travel(Time.new(2022, 4, 12)) }
+    after { Timecop.return }
 
-    expect(client).to have_received(:message_channel).with(
-      hash_including(text: /- #{job.title} at #{job.company}/)
-    )
+    it 'does not post job listings to Slack' do
+      client = stub_slack_client
+      Rake::Task['job_board:digest'].invoke
+
+      expect(client).not_to have_received(:message_channel)
+    end
   end
 
   def stub_slack_client


### PR DESCRIPTION
I was attempting to set up Heroku scheduler to run the job board digest job every Monday. Of course, it doesn't implement that behavior 😆 Instead, you can only set it to run every day at a certain time. Because it's free, I still think we should use it, so I've put a hacky check in the task itself such that it will only run on Mondays.