### PR TITLE
Automatically run db migrations on Heroku deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec rails s
 webpacker: ./bin/webpack-dev-server
+release: bundle exec rails db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: bundle exec rails s
-webpacker: ./bin/webpack-dev-server
 release: bundle exec rails db:migrate

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec rails s
+webpacker: ./bin/webpack-dev-server

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then, edit `.env` and set the following environment variables:
 To start both the frontend and backend servers at the same time, run:
 
 ```
-foreman start
+foreman start -f Procfile.dev
 ```
 
 In your browser, navigate to `localhost:5000` to see the app in action!


### PR DESCRIPTION
Fixes #96

This PR adds a `release` phase to the Procfile file per Heroku Release phase.

Heroku documentation can be found here.
https://devcenter.heroku.com/articles/release-phase#specifying-release-phase-tasks


## Considerations
One consideration / suggestion I would like input on, would be if we'd like to split up the Procfile.dev into
two files. It's often common to have a Procfile.dev file for use during development, and a Procfile to specify
the processes for Production. I would like to create a Procfile.dev with the rails server process and
webpacker, and remove the bin/webpack-dev-server process from the Procfile (so the production procfile would
only be the rails server / release phase)
