### PR TITLE
Replace Date.today with Time.now so Timecop won't get confused

### DIFF
--- a/spec/tasks/job_board/digest_spec.rb
+++ b/spec/tasks/job_board/digest_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'job_board:digest' do
   after(:each) { Rake::Task['job_board:digest'].reenable }
 
   context 'when it is Monday' do
-    before { Timecop.travel(Date.today.last_week(:monday)) }
+    before { Timecop.travel(Time.now.last_week(:monday)) }
     after { Timecop.return }
 
     it 'posts job listings to Slack' do
@@ -23,7 +23,7 @@ RSpec.describe 'job_board:digest' do
   end
 
   context 'when it is not Monday' do
-    before { Timecop.travel(Date.today.last_week(:tuesday)) }
+    before { Timecop.travel(Time.now.last_week(:tuesday)) }
     after { Timecop.return }
 
     it 'does not post job listings to Slack' do


### PR DESCRIPTION
Short version

These specs were failing when I ran them locally. `Date.today` makes Timecop act goofy sometimes. This change makes them pass when run locally on a system west of Eastern Time.

Long version

When Timecop receives a `Date`, it converts it to a time once using a method (`ActiveSupport::TimeZone#local`) that uses the time zone configured in `application.rb` (Eastern Time) and then again using a method (`Time#localtime`) that uses the system time zone.

So the `Date.today.last_week(:monday)` argument passed to Timecop gets transmuted like this:

`Mon, 23 May, 2022` (no time zone) ➡️ `Mon, 23 May 2022 00:00:00.000000000 EDT -04:00` (application time zone) ➡️ `2022-05-22 23:00:00 -0500` (system time zone; if your system's on Central Time, now Timecop thinks it's Sunday)

`Time.now` uses the system time zone, and Timecop doesn't perform all these conversions on `Time` objects.