### PR TITLE
Freeze time for event-related tests

### DIFF
--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -3,7 +3,13 @@
 require './spec/rails_helper'
 
 RSpec.describe Api::EventsController, type: :controller do
-  before { Meetup.destroy_all }
+  before do
+    Meetup.destroy_all
+
+    # Some of these tests may be time-dependent
+    # so we mock the time the tests are run
+    Timecop.freeze(DateTime.new(2022, 3, 30))
+  end
 
   describe 'GET #past' do
     before do


### PR DESCRIPTION
## Problem 

Run `bundle exec rspec` on the main branch and you'll see several failing tests. This is one of them: 

```
  1) Api::EventsController GET #upcoming correctly gets upcoming events
     Failure/Error: expect(body['data']['2022'].count).to eq(2)

       expected: 2
            got: 1

       (compared using ==)
     # ./spec/controllers/api/events_controller_spec.rb:126:in `block (3 levels) in <main>'
```

All of the failing tests are caused by the same problem. The event date set as upcoming events has passed, which means to the test, the event is now in the past, making the tests fail. 

## Solution 

Using TimeCop, this change freezes the DateTime for these tests to make it more resilient for future.

The DateTime picked was arbitrary - just one that works for the current test data.