### PR TITLE
Add more specific page titles 

### DIFF
--- a/app/javascript/components/pages/Donate.jsx
+++ b/app/javascript/components/pages/Donate.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { Helmet } from 'react-helmet';
 import propTypes from 'prop-types';
 import SharedLayout from 'components/layout/SharedLayout';
 import Banner from 'components/Banner';
@@ -14,37 +15,44 @@ const Donate = () => {
     const [selectedPrice, setSelectedPrice] = useState(startingPrice);
 
     return (
-        <SharedLayout>
-            <PageTitleWithContainer text="Donate" />
-            <div className="flex flex-row p-12 justify-center flex-wrap">
-                <div className="flex flex-col mb-20 md:mb-0 md:mr-20">
-                    <h2 className="text-2xl font-medium mb-8">Choose a donation amount</h2>
-                    <DonationAmounts
-                        selectedPrice={selectedPrice}
-                        setSelectedPrice={setSelectedPrice}
-                    />
+        <>
+            <Helmet>
+                <title>Donate | WNB.rb</title>
+            </Helmet>
+
+            <SharedLayout>
+                <PageTitleWithContainer text="Donate" />
+                <div className="flex flex-row p-12 justify-center flex-wrap">
+                    <div className="flex flex-col mb-20 md:mb-0 md:mr-20">
+                        <h2 className="text-2xl font-medium mb-8">Choose a donation amount</h2>
+                        <DonationAmounts
+                            selectedPrice={selectedPrice}
+                            setSelectedPrice={setSelectedPrice}
+                        />
+                    </div>
+                    <div className="max-w-[25rem]">
+                        <h2 className="text-2xl font-medium mb-8">Why give to WNB.rb?</h2>
+                        <p className="mb-5">
+                            Donating to WNB.rb enables us to invest more resources in supporting
+                            women and non-binary people in the Ruby community.
+                        </p>
+                        <p>
+                            Here are some of the initiatives we plan to launch in 2022 with your
+                            help:
+                        </p>
+                        <ul className="list-disc ml-10">
+                            <li>Community fund for educational materials</li>
+                            <li>Travel and housing scholarships for RubyConf and RailsConf</li>
+                            <li>
+                                Workshops for community members on topics such as salary
+                                negotiation, resume writing, and more!
+                            </li>
+                        </ul>
+                    </div>
                 </div>
-                <div className="max-w-[25rem]">
-                    <h2 className="text-2xl font-medium mb-8">Why give to WNB.rb?</h2>
-                    <p className="mb-5">
-                        Donating to WNB.rb enables us to invest more resources in supporting women
-                        and non-binary people in the Ruby community.
-                    </p>
-                    <p>
-                        Here are some of the initiatives we plan to launch in 2022 with your help:
-                    </p>
-                    <ul className="list-disc ml-10">
-                        <li>Community fund for educational materials</li>
-                        <li>Travel and housing scholarships for RubyConf and RailsConf</li>
-                        <li>
-                            Workshops for community members on topics such as salary negotiation,
-                            resume writing, and more!
-                        </li>
-                    </ul>
-                </div>
-            </div>
-            <OtherAmountBanner />
-        </SharedLayout>
+                <OtherAmountBanner />
+            </SharedLayout>
+        </>
     );
 };
 

--- a/app/javascript/components/pages/Home.jsx
+++ b/app/javascript/components/pages/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import SharedLayout from 'components/layout/SharedLayout';
 import SplashBackground from 'components/icons/SplashBackground';
 import Button from 'components/Button';
@@ -54,50 +55,56 @@ const infoCardData = [
 ];
 
 const Home = () => (
-    <SharedLayout>
-        <section className="hero-container">
-            <div className="hero">
-                <PageTitle text="WNB.rb">
-                    <p className="mt-3 max-w-[14rem]">
-                        A virtual community for women and non-binary Rubyists.
-                    </p>
-                    <a
-                        href="https://tinyurl.com/join-wnb-rb"
-                        target="_blank"
-                        rel="noreferrer noopener"
-                    >
-                        <Button type="secondary" className="mt-3">
-                            Join WNB.rb
-                        </Button>
-                    </a>
-                </PageTitle>
-                <div className="splash-background">
-                    <SplashBackground className="w-full" />
+    <>
+        <Helmet>
+            <title>WNB.rb</title>
+        </Helmet>
+
+        <SharedLayout>
+            <section className="hero-container">
+                <div className="hero">
+                    <PageTitle text="WNB.rb">
+                        <p className="mt-3 max-w-[14rem]">
+                            A virtual community for women and non-binary Rubyists.
+                        </p>
+                        <a
+                            href="https://tinyurl.com/join-wnb-rb"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                        >
+                            <Button type="secondary" className="mt-3">
+                                Join WNB.rb
+                            </Button>
+                        </a>
+                    </PageTitle>
+                    <div className="splash-background">
+                        <SplashBackground className="w-full" />
+                    </div>
                 </div>
-            </div>
-        </section>
+            </section>
 
-        <section className="podcast">
-            <PodcastTile podcasts={podcasts} />
-        </section>
+            <section className="podcast">
+                <PodcastTile podcasts={podcasts} />
+            </section>
 
-        <section className="info-card-section">
-            {infoCardData.map((card) => {
-                return (
-                    <InfoCard
-                        key={card.title}
-                        section={card.section}
-                        title={card.title}
-                        icon={card.icon}
-                    ></InfoCard>
-                );
-            })}
-        </section>
+            <section className="info-card-section">
+                {infoCardData.map((card) => {
+                    return (
+                        <InfoCard
+                            key={card.title}
+                            section={card.section}
+                            title={card.title}
+                            icon={card.icon}
+                        ></InfoCard>
+                    );
+                })}
+            </section>
 
-        <section className="sponsors">
-            <SponsorsTile />
-        </section>
-    </SharedLayout>
+            <section className="sponsors">
+                <SponsorsTile />
+            </section>
+        </SharedLayout>
+    </>
 );
 
 export default Home;

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet';
 import propTypes from 'prop-types';
 import { useCookies } from 'react-cookie';
 import SharedLayout from 'components/layout/SharedLayout';
@@ -49,18 +50,23 @@ const Jobs = () => {
     }, [jobs]);
 
     return (
-        <SharedLayout>
-            <PageTitleWithContainer text="Jobs" />
-            {loading ? (
-                <LoadingSpinner />
-            ) : (
-                <>
-                    <JobGroup jobs={firstSixJobs} />
-                    <SponsorUsBanner />
-                    <JobGroup jobs={restOfJobs} />
-                </>
-            )}
-        </SharedLayout>
+        <>
+            <Helmet>
+                <title>Jobs | WNB.rb</title>
+            </Helmet>
+            <SharedLayout>
+                <PageTitleWithContainer text="Jobs" />
+                {loading ? (
+                    <LoadingSpinner />
+                ) : (
+                    <>
+                        <JobGroup jobs={firstSixJobs} />
+                        <SponsorUsBanner />
+                        <JobGroup jobs={restOfJobs} />
+                    </>
+                )}
+            </SharedLayout>
+        </>
     );
 };
 

--- a/app/javascript/components/pages/JobsAuthenticate.jsx
+++ b/app/javascript/components/pages/JobsAuthenticate.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Helmet } from 'react-helmet';
 import { useCookies } from 'react-cookie';
 import SharedLayout from 'components/layout/SharedLayout';
 import Logo from 'components/icons/Logo';
@@ -36,54 +37,59 @@ const JobsAuthenticate = () => {
     };
 
     return (
-        <SharedLayout>
-            <div className="jobs-authenticate-container">
-                <Logo className="h-28" />
-                <Card className="w-full max-w-[30rem] mt-5">
-                    <form className="flex flex-col" onSubmit={(e) => handleLogin(e)}>
-                        Password
-                        <input
-                            type="password"
-                            className="rounded-lg mt-3"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                        ></input>
-                        <Button type="secondary" className="w-40 mt-3">
+        <>
+            <Helmet>
+                <title>Job Board | WNB.rb</title>
+            </Helmet>
+            <SharedLayout>
+                <div className="jobs-authenticate-container">
+                    <Logo className="h-28" />
+                    <Card className="w-full max-w-[30rem] mt-5">
+                        <form className="flex flex-col" onSubmit={(e) => handleLogin(e)}>
+                            Password
                             <input
-                                type="submit"
-                                value="View Job Board"
-                                className="bg-transparent hover:cursor-pointer"
-                            />
-                        </Button>
-                        {hasError && (
-                            <div className="incorrect-password">Password is incorrect.</div>
-                        )}
-                        <p className="text-sm mt-5">
-                            The WNB.rb job board is password protected. You can find the password in
-                            the WNB.rb Slack workspace. To join WNB.rb on Slack,{' '}
-                            <a
-                                href="https://tinyurl.com/join-wnb-rb"
-                                target="_blank"
-                                rel="noreferrer noopener"
-                                className="underline"
-                            >
-                                fill out this form.
-                            </a>
-                        </p>
-                    </form>
-                </Card>
-                <Card className="w-full max-w-[30rem] mt-5">
-                    <div className="flex flex-row flex-wrap items-center justify-center md:justify-between text-lg">
-                        Want to post a job?
-                        <Button type="white" className="mt-3 md:mt-0">
-                            <a href="/sponsor-us" target="_blank" rel="noopener noreferrer">
-                                Sponsor Us
-                            </a>
-                        </Button>
-                    </div>
-                </Card>
-            </div>
-        </SharedLayout>
+                                type="password"
+                                className="rounded-lg mt-3"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                            ></input>
+                            <Button type="secondary" className="w-40 mt-3">
+                                <input
+                                    type="submit"
+                                    value="View Job Board"
+                                    className="bg-transparent hover:cursor-pointer"
+                                />
+                            </Button>
+                            {hasError && (
+                                <div className="incorrect-password">Password is incorrect.</div>
+                            )}
+                            <p className="text-sm mt-5">
+                                The WNB.rb job board is password protected. You can find the
+                                password in the WNB.rb Slack workspace. To join WNB.rb on Slack,{' '}
+                                <a
+                                    href="https://tinyurl.com/join-wnb-rb"
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                    className="underline"
+                                >
+                                    fill out this form.
+                                </a>
+                            </p>
+                        </form>
+                    </Card>
+                    <Card className="w-full max-w-[30rem] mt-5">
+                        <div className="flex flex-row flex-wrap items-center justify-center md:justify-between text-lg">
+                            Want to post a job?
+                            <Button type="white" className="mt-3 md:mt-0">
+                                <a href="/sponsor-us" target="_blank" rel="noopener noreferrer">
+                                    Sponsor Us
+                                </a>
+                            </Button>
+                        </div>
+                    </Card>
+                </div>
+            </SharedLayout>
+        </>
     );
 };
 

--- a/app/javascript/components/pages/Meetups.jsx
+++ b/app/javascript/components/pages/Meetups.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import { getPastMeetups } from '../../datasources';
 import SharedLayout from 'components/layout/SharedLayout';
@@ -106,55 +107,64 @@ const Meetups = () => {
     }, []);
 
     return (
-        <SharedLayout>
-            <PageTitleWithContainer text="Past Meetups" />
-            {loading ? (
-                <LoadingSpinner />
-            ) : (
-                <div className="container flex flex-col mx-auto md:max-w-[50rem] lg:max-w-[73rem]">
-                    {meetupsByYear.length > 0
-                        ? meetupsByYear.reverse().map(([year, meetupsByMonth]) => {
-                              return (
-                                  <YearSection key={year} year={year}>
-                                      {Object.entries(meetupsByMonth).map(([month, meetups]) => {
-                                          return (
-                                              <MonthSection key={month} month={month}>
-                                                  {meetups.map(
-                                                      ({
-                                                          id,
-                                                          speakers,
-                                                          title,
-                                                          date,
-                                                          event_speakers,
-                                                      }) => {
-                                                          const numericMonth =
-                                                              new Date(date).getMonth() + 1;
-                                                          return (
-                                                              <Meetup
-                                                                  key={id}
-                                                                  speakers={speakers}
-                                                                  title={title}
-                                                                  event_speakers={event_speakers}
-                                                                  year={new Date(date)
-                                                                      .getFullYear()
-                                                                      .toString()}
-                                                                  month={numericMonth
-                                                                      .toString()
-                                                                      .padStart(2, '0')}
-                                                              />
-                                                          );
-                                                      },
-                                                  )}
-                                              </MonthSection>
-                                          );
-                                      })}
-                                  </YearSection>
-                              );
-                          })
-                        : null}
-                </div>
-            )}
-        </SharedLayout>
+        <>
+            <Helmet>
+                <title>Past Meetups | WNB.rb</title>
+            </Helmet>
+            <SharedLayout>
+                <PageTitleWithContainer text="Past Meetups" />
+                {loading ? (
+                    <LoadingSpinner />
+                ) : (
+                    <div className="container flex flex-col mx-auto md:max-w-[50rem] lg:max-w-[73rem]">
+                        {meetupsByYear.length > 0
+                            ? meetupsByYear.reverse().map(([year, meetupsByMonth]) => {
+                                  return (
+                                      <YearSection key={year} year={year}>
+                                          {Object.entries(meetupsByMonth).map(
+                                              ([month, meetups]) => {
+                                                  return (
+                                                      <MonthSection key={month} month={month}>
+                                                          {meetups.map(
+                                                              ({
+                                                                  id,
+                                                                  speakers,
+                                                                  title,
+                                                                  date,
+                                                                  event_speakers,
+                                                              }) => {
+                                                                  const numericMonth =
+                                                                      new Date(date).getMonth() + 1;
+                                                                  return (
+                                                                      <Meetup
+                                                                          key={id}
+                                                                          speakers={speakers}
+                                                                          title={title}
+                                                                          event_speakers={
+                                                                              event_speakers
+                                                                          }
+                                                                          year={new Date(date)
+                                                                              .getFullYear()
+                                                                              .toString()}
+                                                                          month={numericMonth
+                                                                              .toString()
+                                                                              .padStart(2, '0')}
+                                                                      />
+                                                                  );
+                                                              },
+                                                          )}
+                                                      </MonthSection>
+                                                  );
+                                              },
+                                          )}
+                                      </YearSection>
+                                  );
+                              })
+                            : null}
+                    </div>
+                )}
+            </SharedLayout>
+        </>
     );
 };
 

--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import { getPastMeetup } from '../../datasources';
 import SharedLayout from 'components/layout/SharedLayout';
@@ -98,47 +99,52 @@ const PastMeetup = () => {
         panel_video_link: panelVideoUrl,
     } = meetup;
     return (
-        <SharedLayout>
-            <div className="max-w-[73rem] px-10 md:px-0 mx-auto my-10 sm:my-20">
-                <PageTitleWithContainer text={`${monthName} ${year} Meetup`} />
-            </div>
-            <div className="container flex mx-auto md:max-w-[50rem] lg:max-w-[73rem]">
-                {loading ? (
-                    <LoadingSpinner />
-                ) : (
-                    <div className="container mx-20">
-                        {panelVideoUrl ? (
-                            <>
-                                <VideoBlock videoUrl={panelVideoUrl} title={title} />
-                                <div className="w-full rounded border-t p-10 border-gray-100 overflow-hidden">
-                                    <h3 className="text-2xl font-bold mx-2 my-2">{title}</h3>
-                                    <SpeakersList speakers={speakers} />
-                                    <p className="m-2 pt-4">{description}</p>
-                                </div>
-                            </>
-                        ) : (
-                            <>
-                                {speakers.map((speaker) => {
-                                    const eventSpeaker = eventSpeakers.filter(
-                                        (es) => es.speaker_id === speaker.id,
-                                    )[0];
-                                    return (
-                                        <SpeakerVideoBlock
-                                            key={speaker.id}
-                                            speaker={speaker}
-                                            eventSpeaker={eventSpeaker}
-                                        />
-                                    );
-                                })}
-                            </>
-                        )}
-                        <div className="flex flex-col items-center bg-gray-100">
-                            <SpeakerBiosBlock speakers={speakers} />
+        <>
+            <Helmet>
+                <title>{`${title} | WNB.rb`}</title>
+            </Helmet>
+            <SharedLayout>
+                <div className="max-w-[73rem] px-10 md:px-0 mx-auto my-10 sm:my-20">
+                    <PageTitleWithContainer text={`${monthName} ${year} Meetup`} />
+                </div>
+                <div className="container flex mx-auto md:max-w-[50rem] lg:max-w-[73rem]">
+                    {loading ? (
+                        <LoadingSpinner />
+                    ) : (
+                        <div className="container mx-20">
+                            {panelVideoUrl ? (
+                                <>
+                                    <VideoBlock videoUrl={panelVideoUrl} title={title} />
+                                    <div className="w-full rounded border-t p-10 border-gray-100 overflow-hidden">
+                                        <h3 className="text-2xl font-bold mx-2 my-2">{title}</h3>
+                                        <SpeakersList speakers={speakers} />
+                                        <p className="m-2 pt-4">{description}</p>
+                                    </div>
+                                </>
+                            ) : (
+                                <>
+                                    {speakers.map((speaker) => {
+                                        const eventSpeaker = eventSpeakers.filter(
+                                            (es) => es.speaker_id === speaker.id,
+                                        )[0];
+                                        return (
+                                            <SpeakerVideoBlock
+                                                key={speaker.id}
+                                                speaker={speaker}
+                                                eventSpeaker={eventSpeaker}
+                                            />
+                                        );
+                                    })}
+                                </>
+                            )}
+                            <div className="flex flex-col items-center bg-gray-100">
+                                <SpeakerBiosBlock speakers={speakers} />
+                            </div>
                         </div>
-                    </div>
-                )}
-            </div>
-        </SharedLayout>
+                    )}
+                </div>
+            </SharedLayout>
+        </>
     );
 };
 

--- a/app/javascript/components/pages/SponsorUs.jsx
+++ b/app/javascript/components/pages/SponsorUs.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Helmet } from 'react-helmet';
 import SharedLayout from 'components/layout/SharedLayout';
 import SponsorCard from '../sponsor_us/SponsorCard';
 import PageTitleWithContainer from 'components/PageTitleWithContainer';
@@ -10,39 +11,44 @@ import 'stylesheets/sponsor-us';
 
 const SponsorUs = () => {
     return (
-        <SharedLayout>
-            <PageTitleWithContainer text="Sponsor Us" />
+        <>
+            <Helmet>
+                <title>Sponsor Us | WNB.rb</title>
+            </Helmet>
+            <SharedLayout>
+                <PageTitleWithContainer text="Sponsor Us" />
 
-            <div className="text-xl leading-8 max-w-[550px] mx-auto mb-24 text-center">
-                <p>Thank you for your interest in sponsoring WNB.rb!</p>
-                <p className="mt-10">
-                    We are currently revamping our sponsorship process for all new sponsors. If you
-                    would like to be notified when our new sponsorship process is ready, please fill
-                    out{' '}
-                    <a
-                        href="https://docs.google.com/forms/d/e/1FAIpQLSeMRuBCYfDsh8KsnKfgFiaKOs327syoSbtj63j8kG_HSn4AMw/viewform"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        this form
-                    </a>
-                    .
-                </p>
-                <p className="mt-10">
-                    In the meantime, we encourage you to invite any women or non-binary developers
-                    on your team to{' '}
-                    <a
-                        href="https://tinyurl.com/join-wnb-rb"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        join our community
-                    </a>
-                    . Getting to know the engineers who work for our sponsors helps our sponsorships
-                    succeed!
-                </p>
-            </div>
-        </SharedLayout>
+                <div className="text-xl leading-8 max-w-[550px] mx-auto mb-24 text-center">
+                    <p>Thank you for your interest in sponsoring WNB.rb!</p>
+                    <p className="mt-10">
+                        We are currently revamping our sponsorship process for all new sponsors. If
+                        you would like to be notified when our new sponsorship process is ready,
+                        please fill out{' '}
+                        <a
+                            href="https://docs.google.com/forms/d/e/1FAIpQLSeMRuBCYfDsh8KsnKfgFiaKOs327syoSbtj63j8kG_HSn4AMw/viewform"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            this form
+                        </a>
+                        .
+                    </p>
+                    <p className="mt-10">
+                        In the meantime, we encourage you to invite any women or non-binary
+                        developers on your team to{' '}
+                        <a
+                            href="https://tinyurl.com/join-wnb-rb"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            join our community
+                        </a>
+                        . Getting to know the engineers who work for our sponsors helps our
+                        sponsorships succeed!
+                    </p>
+                </div>
+            </SharedLayout>
+        </>
     );
 };
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "react": "^17.0.2",
         "react-cookie": "^4.1.1",
         "react-dom": "^17.0.2",
+        "react-helmet": "^6.1.0",
         "sass": "^1.43.4",
         "sass-loader": "^10.1.1",
         "tailwindcss": "^2.2.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8095,6 +8095,21 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -8104,6 +8119,11 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-side-effect@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
+  integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
 react@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
Resolves: https://github.com/wnbrb/wnb-rb-site/issues/75

Because of how the header (in application.erb) is set up, we cannot retroactively set the `title` once the page's body / javascript script is rendered. Anyway, I used `react-helmet`'s [Helmet component](https://github.com/nfl/react-helmet) for in each of the page component to set the titles. 

Examples: 
<img width="339" alt="Screen Shot 2022-09-02 at 6 56 25 PM" src="https://user-images.githubusercontent.com/25471753/188244332-ca8fc9bc-855b-49f0-9876-6c3b2f7b29d7.png">
<img width="345" alt="Screen Shot 2022-09-02 at 7 01 47 PM" src="https://user-images.githubusercontent.com/25471753/188244662-d519b9bf-be7e-41f3-9b68-b60a65d949b6.png">



