### PR TITLE
Fix: past meetups page grey bar alignment issue

### DIFF
--- a/app/javascript/components/pages/Meetups.jsx
+++ b/app/javascript/components/pages/Meetups.jsx
@@ -22,7 +22,7 @@ YearSection.propTypes = {
 
 const MonthSection = ({ children, month }) => (
     <li key={month} className="meetups__month flex flex-col items-start md:flex-row">
-        <div className="meetups__month--name w-28">
+        <div className="meetups__month--name w-36">
             <h3 className="py-1 px-2 mb-4 w-min border-2 border-red-400 rounded uppercase text-md text-red-400 md:ml-auto">
                 {month}
             </h3>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -127,6 +127,36 @@ EventSpeaker.create(
                      lectus a sapien vulputate auctor sit amet sit amet augue.',
 )
 
+p 'Create a third meetup'
+
+meetup3 =
+  Meetup.create(
+    title: 'September 2021 Meetup',
+    description: 'Our meetup in September ',
+    date: DateTime.new(2021, 9, 28, 16).utc,
+    panel_video_link: 'https://www.youtube.com/embed/GlpZPv1bp4g',
+  )
+
+EventSpeaker.create(
+  event: meetup3,
+  speaker: jemma,
+  talk_title: 'A talk given at the September meetup',
+  talk_video_link: 'https://www.youtube.com/embed/n43O0u77d8o',
+  talk_description:
+    'Cras elementum, tortor id faucibus iaculis, augue metus
+                     pretium massa, luctus auctor odio ligula vel justo. Sed
+                     lacinia hendrerit felis, et dictum ante porttitor in.
+                     Suspendisse ut sem dolor. In hac habitasse platea dictumst.
+                     Maecenas dapibus ex nisi, quis pretium odio ultrices ac.
+                     Nunc ligula nunc, gravida porttitor felis dignissim, euismod
+                     posuere ante. Curabitur congue tellus purus, id posuere sem
+                     maximus fermentum. Aenean vehicula ipsum nec condimentum
+                     vehicula. Nunc sit amet imperdiet elit. Proin lacinia sed
+                     dui pharetra sollicitudin. Maecenas vel enim a ante suscipit
+                     aliquam. Cras placerat elit eu ultricies pulvinar. Cras et
+                     lectus a sapien vulputate auctor sit amet sit amet augue.',
+)
+
 p 'Create a panel with three panelists'
 
 kerstin =


### PR DESCRIPTION
Fixes: https://github.com/wnbrb/wnb-rb-site/issues/130

It seems that the bar was misaligned because some months have longer words than others. Increasing the width of the little month box fixed it!

To be able to test this locally I added another meetup event to the seeds. I created it for September because that's the month with the most characters.

Before and after shots 💅 

**Before: grey bar is broken up**
![image](https://user-images.githubusercontent.com/8995723/204732570-81ad1186-9d44-4e71-ba2b-fc5820607c12.png)

**After: all in one line!**
![image](https://user-images.githubusercontent.com/8995723/204732478-02abf5c4-5394-4e42-9b3d-3b13189f7550.png)
