### PR TITLE
Add speaker links to speaker table

### DIFF
--- a/db/migrate/20221208080716_add_links_to_speakers.rb
+++ b/db/migrate/20221208080716_add_links_to_speakers.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddLinksToSpeakers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :speakers, :links, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_29_221831) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_12_08_080716) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,8 +20,8 @@ ActiveRecord::Schema.define(version: 2022_01_29_221831) do
     t.text "talk_video_link"
     t.bigint "speaker_id", null: false
     t.bigint "event_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["event_id"], name: "index_event_speakers_on_event_id"
     t.index ["speaker_id"], name: "index_event_speakers_on_speaker_id"
   end
@@ -31,11 +30,11 @@ ActiveRecord::Schema.define(version: 2022_01_29_221831) do
     t.string "title"
     t.string "location", default: "virtual"
     t.text "description"
-    t.datetime "date"
+    t.datetime "date", precision: nil
     t.string "type", null: false
     t.text "panel_video_link"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "jobs", force: :cascade do |t|
@@ -44,8 +43,8 @@ ActiveRecord::Schema.define(version: 2022_01_29_221831) do
     t.text "description"
     t.string "link"
     t.string "location"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "image_url"
     t.integer "sponsorship_level"
   end
@@ -54,9 +53,10 @@ ActiveRecord::Schema.define(version: 2022_01_29_221831) do
     t.string "name"
     t.text "bio"
     t.string "tagline"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "image_url"
+    t.jsonb "links", default: {}
   end
 
   create_table "users", force: :cascade do |t|
@@ -64,15 +64,15 @@ ActiveRecord::Schema.define(version: 2022_01_29_221831) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ jemma =
     name: 'Jemma Issroff',
     tagline: 'Creator and Maintainer of MemoWise',
     bio:
-      "Lorem Ipsum is simply dummy text of the printing
+    "Lorem Ipsum is simply dummy text of the printing
   and typesetting industry. Lorem Ipsum has been the
   industry's standard dummy text ever since the 1500s,
   when an unknown printer took a galley of type and
@@ -27,8 +27,12 @@ jemma =
   passages, and more recently with desktop publishing
   software like Aldus PageMaker including versions of Lorem
   Ipsum.",
-    image_url: 'https://picsum.photos/200/300',
-  )
+  image_url: 'https://picsum.photos/200/300',
+  links: {
+    twitter: 'http://example.com/jemmas-twitter',
+    personal_website: 'http://example.com/jemmas-personal-website',
+  }
+)
 
 stefanni =
   Speaker.create(

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe Api::EventsController, type: :controller do
           tagline: 'Software Developer',
           bio: 'Lorem Ipsum',
           image_url: 'https://picsum.photos/200',
+          links: {
+            twitter: 'http://example.com/twitter-link',
+            mastodon: 'http://example.com/mastodon-link',
+            personal_website: 'http://example.com/personal-website-link',
+          }
         )
       EventSpeaker.create(
         event: july_meetup,
@@ -64,7 +69,13 @@ RSpec.describe Api::EventsController, type: :controller do
       body = JSON.parse(response.body)
 
       july_meetup = body['data']['2021']['July'].first
+
       expect(july_meetup['speakers'].first['name']).to eq('Speaker Name')
+      expect(july_meetup['speakers'].first['links']).to eq({
+        'twitter' => 'http://example.com/twitter-link',
+        'mastodon' => 'http://example.com/mastodon-link',
+        'personal_website' => 'http://example.com/personal-website-link',
+      })
     end
 
     it 'includes talk titles' do
@@ -148,6 +159,7 @@ RSpec.describe Api::EventsController, type: :controller do
 
       august_meetup = body['data']['2022']['August'].first
       expect(august_meetup['speakers'].first['name']).to eq('Speaker Name')
+      expect(august_meetup['speakers'].first['links']).to eq({})
     end
   end
 end


### PR DESCRIPTION
Related: https://github.com/wnbrb/wnb-rb-site/issues/124

- added a jsonb column for the speaker links

Question:
1) I called the new column `links` and I don't love it. Because it's a plural word it makes me think that the data should be an array. But it's a hash/object with a structure of `{social_media_platform: 'link-to-profile-on-platform'}`. What do you think?
Better ideas for a name are welcome!

Next steps:
I'd like to implement the frontend in a separate PR. More info (with request for feedback) added to the issue. https://github.com/wnbrb/wnb-rb-site/issues/124

