### PR TITLE
adjusted apply button on job board page

### DIFF
--- a/app/javascript/components/Card.jsx
+++ b/app/javascript/components/Card.jsx
@@ -1,28 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Button from 'components/Button';
 
 import 'stylesheets/card';
 
-const Card = ({ children, className, link }) => (
-    <>
-        <div className={`card p-10 ${className}`}>
-            {children}
-            <div className="flex flex-row justify-between items-center space-x-5">
-                <Button type="white" className="w-20">
-                    <a href={link} target="_blank" rel="noopener noreferrer">
-                        Apply
-                    </a>
-                </Button>
-            </div>
-        </div>
-    </>
+const Card = ({ children, className }) => (
+    <div className={`card p-10 ${className}`}>{children} </div>
 );
 
 Card.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    link: PropTypes.string,
+    link: PropTypes.boolean,
 };
 
 export default Card;

--- a/app/javascript/components/Card.jsx
+++ b/app/javascript/components/Card.jsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Button from 'components/Button';
 
 import 'stylesheets/card';
 
-const Card = ({ children, className }) => (
-    <div className={`card p-10 ${className}`}>{children}</div>
+const Card = ({ children, className, link }) => (
+    <>
+        <div className={`card p-10 ${className}`}>
+            {children}
+            <div className="flex flex-row justify-between items-center space-x-5">
+                <Button type="white" className="w-20">
+                    <a href={link} target="_blank" rel="noopener noreferrer">
+                        Apply
+                    </a>
+                </Button>
+            </div>
+        </div>
+    </>
 );
 
 Card.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
+    link: PropTypes.string,
 };
 
 export default Card;

--- a/app/javascript/components/Card.jsx
+++ b/app/javascript/components/Card.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import 'stylesheets/card';
 
 const Card = ({ children, className }) => (
-    <div className={`card p-10 ${className}`}>{children} </div>
+    <div className={`card p-10 ${className}`}>{children}</div>
 );
 
 Card.propTypes = {

--- a/app/javascript/components/Card.jsx
+++ b/app/javascript/components/Card.jsx
@@ -10,7 +10,6 @@ const Card = ({ children, className }) => (
 Card.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    link: PropTypes.boolean,
 };
 
 export default Card;

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -105,7 +105,7 @@ const SponsorUsBanner = () => {
     );
 };
 
-const Job = ({ title, description, imageUrl, company, location, link }) => {
+const Job = ({ title, description, imageUrl, company, link, location }) => {
     return (
         <Card className="mx-0 my-5 md:mr-8 max-w-[22rem]">
             <div className="flex flex-row">

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -116,7 +116,7 @@ const Job = ({ title, description, imageUrl, company, link, location }) => {
                     <div className="font-light">{location}</div>
                 </div>
             </div>
-            <div className="my-5 h-44">{description}</div>
+            <div className="my-5 h-48">{description}</div>
             <div className="flex flex-row justify-between items-center space-x-5">
                 <Button type="white" className="w-20">
                     <a href={link} target="_blank" rel="noopener noreferrer">

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -116,7 +116,7 @@ const Job = ({ title, description, imageUrl, company, link, location }) => {
                     <div className="font-light">{location}</div>
                 </div>
             </div>
-            <div className="my-5 h-48">{description}</div>
+            <div className="my-5 h-44">{description}</div>
             <div className="flex flex-row justify-between items-center space-x-5">
                 <Button type="white" className="w-20">
                     <a href={link} target="_blank" rel="noopener noreferrer">

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -116,7 +116,7 @@ const Job = ({ title, description, imageUrl, company, link, location }) => {
                     <div className="font-light">{location}</div>
                 </div>
             </div>
-            <div className="my-5 h-44">{description}</div>
+            <div className="my-5">{description}</div>
             <div className="flex flex-row justify-between items-center space-x-5">
                 <Button type="white" className="w-20">
                     <a href={link} target="_blank" rel="noopener noreferrer">

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -116,7 +116,7 @@ const Job = ({ title, description, imageUrl, company, link, location }) => {
                     <div className="font-light">{location}</div>
                 </div>
             </div>
-            <div className="my-5">{description}</div>
+            <div className="my-5 h-44">{description}</div>
             <div className="flex flex-row justify-between items-center space-x-5">
                 <Button type="white" className="w-20">
                     <a href={link} target="_blank" rel="noopener noreferrer">

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -105,7 +105,7 @@ const SponsorUsBanner = () => {
     );
 };
 
-const Job = ({ title, description, imageUrl, company, link, location }) => {
+const Job = ({ title, description, imageUrl, company, location }) => {
     return (
         <Card className="mx-0 my-5 md:mr-8 max-w-[22rem]">
             <div className="flex flex-row">
@@ -116,14 +116,7 @@ const Job = ({ title, description, imageUrl, company, link, location }) => {
                     <div className="font-light">{location}</div>
                 </div>
             </div>
-            <div className="my-5 h-48">{description}</div>
-            <div className="flex flex-row justify-between items-center space-x-5">
-                <Button type="white" className="w-20">
-                    <a href={link} target="_blank" rel="noopener noreferrer">
-                        Apply
-                    </a>
-                </Button>
-            </div>
+            <div className="my-5 h-44">{description}</div>
         </Card>
     );
 };

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -105,7 +105,7 @@ const SponsorUsBanner = () => {
     );
 };
 
-const Job = ({ title, description, imageUrl, company, location }) => {
+const Job = ({ title, description, imageUrl, company, location, link }) => {
     return (
         <Card className="mx-0 my-5 md:mr-8 max-w-[22rem]">
             <div className="flex flex-row">
@@ -116,7 +116,14 @@ const Job = ({ title, description, imageUrl, company, location }) => {
                     <div className="font-light">{location}</div>
                 </div>
             </div>
-            <div className="my-5 h-44">{description}</div>
+            <div className="my-5 h-48">{description} </div>
+            <div className="flex flex-row justify-between items-center space-x-5">
+                <Button type="white" className="w-20">
+                    <a href={link} target="_blank" rel="noopener noreferrer">
+                        Apply
+                    </a>
+                </Button>
+            </div>
         </Card>
     );
 };

--- a/app/javascript/components/pages/Jobs.jsx
+++ b/app/javascript/components/pages/Jobs.jsx
@@ -116,7 +116,7 @@ const Job = ({ title, description, imageUrl, company, link, location }) => {
                     <div className="font-light">{location}</div>
                 </div>
             </div>
-            <div className="my-5 h-48">{description} </div>
+            <div className="my-5 h-48">{description}</div>
             <div className="flex flex-row justify-between items-center space-x-5">
                 <Button type="white" className="w-20">
                     <a href={link} target="_blank" rel="noopener noreferrer">

--- a/app/javascript/stylesheets/jobs.scss
+++ b/app/javascript/stylesheets/jobs.scss
@@ -7,4 +7,5 @@
       md:max-w-[50rem]
       lg:max-w-[73rem]
       mx-auto;
+      flex-grow: 1;
 }


### PR DESCRIPTION
@luciagirasoles In this PR I made one small change, which was adjusting the description height in `Jobs.jsx`. I'm not sure if this is the best solution. I would love your feedback.

I tested this on my local server with the fake data and it looks fine. I also wanted to double check my work and since I didn't have the latest production data, I went to the main site and clicked on `inspect` and I adjusted all the heights for the job description to see how it would look like on production. Everything looks fine, except for one job (Weedmaps) the Appy button is pretty close to the job description, therefore, there is a big gap between the Appy button and the bottom of the box. I've attached a picture. Let me know what you think. 

Main site
<img width="837" alt="Screenshot 2023-02-03 at 3 13 45 PM" src="https://user-images.githubusercontent.com/15877132/216706167-4462199b-af9e-4948-8e30-f6993cc172d9.png">

Local server
<img width="934" alt="Screenshot 2023-02-03 at 3 14 12 PM" src="https://user-images.githubusercontent.com/15877132/216706644-3fd0ca6e-d625-4dd9-b938-01609dee5efb.png">

Is there a way to pull the latest data from production? 