### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
A warning message is displayed by GitHub Actions. This PR corrects the noted deprecation.

<img width="1211" alt="Screenshot 2023-10-09 at 1 40 27 PM" src="https://github.com/wnbrb/wnb-rb-site/assets/26725925/c78c57d9-4a71-40da-912c-281d06b5ca52">

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
