### PR TITLE
move devise helpers into support file

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,9 +70,6 @@ RSpec.configure do |config|
 
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-
-  config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include Devise::Test::ControllerHelpers, type: :view
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
   config.include Warden::Test::Helpers
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
 end


### PR DESCRIPTION
Move devise helpers from `/spec/rails_helper.rb` to `/spec/support/devise.rb`