### PR TITLE
Remove unnecessary dependency on the timecop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ group :test do
   gem 'factory_bot_rails', '~> 6.2.0'
   gem 'selenium-webdriver', '~> 4.8.1'
   gem 'shoulda-matchers', '~>5.3.0'
-  gem 'timecop', '~> 0.9.6'
   gem 'webdrivers', '~>5.2.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,6 @@ GEM
       railties (>= 6.0.0)
     thor (1.2.2)
     tilt (2.2.0)
-    timecop (0.9.6)
     timeout (0.4.0)
     trailblazer-option (0.1.2)
     truncate_html (0.9.3)
@@ -436,7 +435,6 @@ DEPENDENCIES
   shoulda-matchers (~> 5.3.0)
   slack-ruby-client (~> 2.0.0)
   stimulus-rails (~> 1.2.1)
-  timecop (~> 0.9.6)
   truncate_html (~> 0.9.3)
   turbo-rails (~> 1.4.0)
   tzinfo-data

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe Api::EventsController, type: :controller do
 
     # Some of these tests may be time-dependent
     # so we mock the time the tests are run
-    Timecop.freeze(DateTime.new(2022, 3, 30))
+    travel_to(DateTime.new(2022, 3, 30))
   end
+
+  after { travel_back }
 
   describe 'GET #past' do
     before do

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+RSpec.configure { |config| config.include ActiveSupport::Testing::TimeHelpers }

--- a/spec/tasks/job_board/digest_spec.rb
+++ b/spec/tasks/job_board/digest_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'job_board:digest' do
   after(:each) { Rake::Task['job_board:digest'].reenable }
 
   context 'when it is Monday' do
-    before { Timecop.travel(Time.now.last_week(:monday)) }
-    after { Timecop.return }
+    before { travel_to(Time.now.last_week(:monday)) }
+    after { travel_back }
 
     it 'posts job listings to Slack' do
       client = stub_slack_client
@@ -23,8 +23,8 @@ RSpec.describe 'job_board:digest' do
   end
 
   context 'when it is not Monday' do
-    before { Timecop.travel(Time.now.last_week(:tuesday)) }
-    after { Timecop.return }
+    before { travel_to(Time.now.last_week(:tuesday)) }
+    after { travel_back }
 
     it 'does not post job listings to Slack' do
       client = stub_slack_client


### PR DESCRIPTION
Since Rails 4.1, Active Support includes its own timehelpers, rendering the timecop gem unnecessary. This PR removes the dependency on timecop and updates the codebase to utilize the built-in timehelpers provided by Active Support. This change improves the efficiency and maintainability of the codebase.