### PR TITLE
Verify embedded YouTube videos url link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,8 @@ group :development, :test do
   gem 'pry-rails', '~> 0.3.9'
 
   # Run tests
-  gem 'rspec-rails', '~> 6.0.1'
   gem 'rails-controller-testing', '~> 1.0.5'
+  gem 'rspec-rails', '~> 6.0.1'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'truncate_html', '~> 0.9.3'
 gem 'httpparty', '~> 0.2'
 
 # pagination
-gem 'pagy', "~> 6.2"
+gem 'pagy', '~> 6.2'
 
 group :development, :test do
   # Annotate models, routes, fixtures, and others based on the database schema
@@ -58,7 +58,6 @@ group :development, :test do
 
   # Run tests
   gem 'rspec-rails', '~> 6.0.1'
-
   gem 'rails-controller-testing', '~> 1.0.5'
 end
 

--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -16,7 +16,7 @@ const VideoBlock = ({ videoUrl, title }) => {
     }
     return (
         <div className="card-container flex flex-wrap justify-center aspect-w-16 aspect-h-9">
-            <iframe src={videoUrl} title={title} frameBorder="0"></iframe>;
+            <iframe src={videoUrl} title={title} style={{ border: 'none' }}></iframe>;
         </div>
     );
 };

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -28,8 +28,14 @@ class Talk < ApplicationRecord
   belongs_to :event, optional: true
 
   validates :talk_title, :talk_description, presence: true, unless: :panel_event?
+  validate :validate_video_link, if: ->(t) { t.talk_video_link.present? }
 
   default_scope { order(id: :asc) }
+
+  def validate_video_link
+    return unless talk_video_link.present? && !talk_video_link.include?('/embed')
+    errors.add(:talk_video_link, ', please provide a YouTube link in the following format: https://www.youtube.com/embed/VIDEO_ID')
+  end
 
   def panel_event?
     event.is_a?(Panel)

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe Talk, type: :model do
       it { is_expected.not_to validate_presence_of(:talk_title) }
       it { is_expected.not_to validate_presence_of(:talk_description) }
     end
+
+    context 'when the talk video link is present' do
+      it 'validates the format of the talk video link' do
+        talk = build(:talk, talk_video_link: 'https://www.youtube.com/embed/VIDEO_CODE')
+        expect(talk).to be_valid
+
+        talk.talk_video_link = 'invalid_link'
+        expect(talk).to be_invalid
+        expect(talk.errors[:talk_video_link]).to include(', please provide a YouTube link in the following format: https://www.youtube.com/embed/VIDEO_ID')
+      end
+    end
   end
 
   describe 'scopes' do


### PR DESCRIPTION
- `https://www.youtube.com/embed/VIDEO_ID` is the[ required format ](https://developers.google.com/youtube/player_parameters#Manual_IFrame_Embeds)for the iframe tag from PastMeetup.jsx. This PR includes an error message that appears when the URL doesn't match. 
<img width="300" alt="Screenshot 2023-12-25 at 4 40 47 PM" src="https://github.com/wnbrb/wnb-rb-site/assets/26725925/66666521-7da9-46f1-911e-1e67045c74fd">
