### PR TITLE
66 add custom 404 page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,14 +12,14 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :render_unauthorized
 
+  def render_not_found
+    render('not_found', status: :not_found)
+  end
+
   private
 
   def render_unauthorized
     render status: 401, json: {}
-  end
-
-  def render_not_found
-    render(file: "#{Rails.root}/public/404.html", status: :not_found)
   end
 
   def validate_recaptcha(token_recaptcha)

--- a/app/javascript/components/pages/NotFound.jsx
+++ b/app/javascript/components/pages/NotFound.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import SharedLayout from 'components/layout/SharedLayout';
+import RubyOutline from 'components/icons/RubyOutline';
+
+import 'stylesheets/not_found';
+
+const NotFound = () => (
+    <>
+        <Helmet>
+            <title>WNB.rb: 404</title>
+        </Helmet>
+
+        <SharedLayout>
+            <div className="not-found-container">
+                <RubyOutline className="h-60 w-60" />
+                <div className="not-found-text-container">
+                    <h1 className="title-text-lg">404</h1>
+                    <p>We couldn&apos;t find the page you were looking for.</p>
+                </div>
+            </div>
+        </SharedLayout>
+    </>
+);
+
+export default NotFound;

--- a/app/javascript/packs/not_found.jsx
+++ b/app/javascript/packs/not_found.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
+import NotFound from '../components/pages/NotFound';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('root');
+    const root = createRoot(container);
+
+    root.render(
+        <HelmetProvider>
+            <NotFound />
+        </HelmetProvider>,
+    );
+});

--- a/app/javascript/stylesheets/not_found.scss
+++ b/app/javascript/stylesheets/not_found.scss
@@ -23,7 +23,8 @@
 .not-found-text-container {
     @apply absolute 
     top-1/2 
-    text-center;
+    text-center
+    w-11/12;
 
     transform: translateY(-50%);
 }

--- a/app/javascript/stylesheets/not_found.scss
+++ b/app/javascript/stylesheets/not_found.scss
@@ -1,0 +1,29 @@
+.title-text-lg {
+    @apply text-wnbrb-pink-default
+    text-8xl
+    font-black
+    md:whitespace-nowrap;
+
+    -webkit-text-stroke-width: 2px;
+    -webkit-text-stroke-color: white;
+    text-shadow: 0px 2px 6px rgb(0 0 0 / 15%);
+}
+
+.not-found-container {
+    @apply mt-20
+    mb-4 
+    mx-auto 
+    p-5 
+    flex
+    items-center 
+    justify-center 
+    relative;
+}
+
+.not-found-text-container {
+    @apply absolute 
+    top-1/2 
+    text-center;
+
+    transform: translateY(-50%);
+}

--- a/app/views/application/not_found.html.erb
+++ b/app/views/application/not_found.html.erb
@@ -1,0 +1,2 @@
+<%= append_javascript_pack_tag 'not_found' %>
+<%= append_stylesheet_pack_tag 'not_found' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,4 +49,6 @@ Rails.application.routes.draw do
 
   mount ActionCable.server => '/cable'
   resources :grid
+
+  match '*unmatched', to: 'application#render_not_found', via: :all
 end

--- a/spec/system/visit_site_pages_spec.rb
+++ b/spec/system/visit_site_pages_spec.rb
@@ -52,4 +52,23 @@ RSpec.describe 'User visit site pages', type: :system, js: true do
 
     expect(page).to have_text(meetup.title)
   end
+
+  context 'visit to unknown path' do
+    before do
+      method = Rails.application.method(:env_config)
+      allow(Rails.application).to receive(:env_config).with(no_args) do
+        method.call.merge(
+          'action_dispatch.show_exceptions' => true,
+          'action_dispatch.show_detailed_exceptions' => false,
+          'consider_all_requests_local' => false
+        )
+      end
+    end
+
+    it 'responds with not found page' do
+      visit '/nonexistentpath'
+
+      expect(page).to have_text('404')
+    end
+  end
 end


### PR DESCRIPTION
Issue #66

This pull creates a custom not found page consistent with the theme of the site. 

I modified the existing application#render_not_found method and added a views/application directory to hold the view. I'm not sure if that is how you would like it. Maybe it would be better in the views/site directory? Let me know and I can change it. 

I also added a test. Again, not sure where the best place for it is. 

<img width="1097" alt="Screenshot 2024-01-13 at 7 25 49 AM" src="https://github.com/wnbrb/wnb-rb-site/assets/82609260/b247b28b-5a7b-4524-bc67-b6291a489df3">

<img width="391" alt="Screenshot 2024-01-13 at 7 23 50 AM" src="https://github.com/wnbrb/wnb-rb-site/assets/82609260/03ddb453-dbf9-4efe-be5a-0cae1ca346fe">

