### PR TITLE
92 allow donate amount of choosing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,5 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Explicitly depend on and compile nokogiri
 # so we can run CI on Ruby head
 gem 'nokogiri', '~> 1.14', force_ruby_platform: true
+
+gem 'stripe'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,7 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    stripe (10.6.0)
     thor (1.2.2)
     tilt (2.2.0)
     timeout (0.4.0)
@@ -436,6 +437,7 @@ DEPENDENCIES
   shoulda-matchers (~> 5.3.0)
   slack-ruby-client (~> 2.0.0)
   stimulus-rails (~> 1.2.1)
+  stripe
   truncate_html (~> 0.9.3)
   turbo-rails (~> 1.4.0)
   tzinfo-data

--- a/app/controllers/api/donations_controller.rb
+++ b/app/controllers/api/donations_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Api
+  class DonationsController < ApplicationController
+    def create
+      Stripe.api_key = stripe_key
+
+      session = Stripe::Checkout::Session.create({
+        line_items: [{
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: 'Donation',
+            },
+            unit_amount: price_in_cents,
+          },
+          quantity: 1,
+        }],
+        mode: 'payment',
+        # required by stripe
+        success_url: 'https://wnb-rb.dev',
+        cancel_url: 'https://wnb-rb.dev/donate',
+      })
+      render json: { url: session.url }
+    end
+
+    private
+
+    def stripe_key
+      ENV.fetch('STRIPE_KEY', nil)
+    end
+
+    def price_in_cents
+      donation_params[:price].to_i * 100
+    end
+
+    def donation_params
+      params.require(:donation).permit(:price)
+    end
+  end
+end

--- a/app/javascript/components/pages/Donate.jsx
+++ b/app/javascript/components/pages/Donate.jsx
@@ -64,6 +64,15 @@ const DonationAmounts = ({ selectedPrice, setSelectedPrice }) => {
         })[0];
     }, [prices, selectedPrice]);
 
+    const [otherSelected, setOtherSelected] = useState(false);
+
+    const donateOtherHandler = () => {};
+
+    const selectSetPrice = (value) => {
+        setSelectedPrice(value);
+        setOtherSelected(false);
+    };
+
     return (
         <div className="flex justify-center">
             <div className="donation-amounts">
@@ -72,19 +81,41 @@ const DonationAmounts = ({ selectedPrice, setSelectedPrice }) => {
                         <button
                             key={price.value}
                             className={`donation-amount ${
-                                selectedPrice === price.value ? 'selected' : null
+                                selectedPrice === price.value && !otherSelected ? 'selected' : null
                             }`}
-                            onClick={() => setSelectedPrice(price.value)}
+                            onClick={() => selectSetPrice(price.value)}
                         >
                             ${price.value.toLocaleString()}
                         </button>
                     );
                 })}
-                <Button type="secondary" className="donate-button">
-                    <a href={selectedPriceObject.link} target="_blank" rel="noopener noreferrer">
-                        Donate ${selectedPriceObject.value.toLocaleString()}
-                    </a>
-                </Button>
+                <form
+                    className={`donation-amount flex-col p-1 ${otherSelected ? 'selected' : null}`}
+                >
+                    <label htmlFor="other">Other</label>
+                    <input
+                        id="other"
+                        type="text"
+                        className="max-w-full m-0 p-1"
+                        onClick={() => setOtherSelected(true)}
+                    />
+                </form>
+                {!otherSelected && (
+                    <Button type="secondary" className="donate-button">
+                        <a
+                            href={selectedPriceObject.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Donate ${selectedPriceObject.value.toLocaleString()}
+                        </a>
+                    </Button>
+                )}
+                {otherSelected && (
+                    <button className="button secondary donate-button" onClick={donateOtherHandler}>
+                        Donate
+                    </button>
+                )}
             </div>
         </div>
     );

--- a/app/javascript/datasources/index.js
+++ b/app/javascript/datasources/index.js
@@ -77,7 +77,6 @@ export const donationAmounts = (environment) => {
 };
 
 const testDonationAmounts = [
-    { value: 10, link: 'https://buy.stripe.com/test_fZe3cr0hWfIN0i4289' },
     { value: 25, link: 'https://buy.stripe.com/test_14k3crfcQaot7Kw6oq' },
     { value: 50, link: 'https://buy.stripe.com/test_6oEaET9Sw1RXfcY8wz' },
     { value: 75, link: 'https://buy.stripe.com/test_8wM28n4yc7chfcY007' },
@@ -88,7 +87,6 @@ const testDonationAmounts = [
 ];
 
 const productionDonationAmounts = [
-    { value: 10, link: 'https://buy.stripe.com/14k14KcpbcJ4bwQbIK' },
     { value: 25, link: 'https://buy.stripe.com/dR600G74RbF0fN6003' },
     { value: 50, link: 'https://buy.stripe.com/7sI00G60N9wSeJ2bIM' },
     { value: 75, link: 'https://buy.stripe.com/6oEeVA60NbF06cwcMR' },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
     end
 
     post 'register-user', to: 'registrations#register_user'
+
+    resources :donations, only: [:create]
   end
 
   mount ActionCable.server => '/cable'

--- a/spec/controllers/api/donations_controller_spec.rb
+++ b/spec/controllers/api/donations_controller_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require './spec/rails_helper'
+
+RSpec.describe Api::DonationsController, type: :controller do
+  describe 'POST #create' do
+    it 'calls create on a stripe checkout session' do
+      expect(Stripe::Checkout::Session).to receive(:create).and_return(double(url: 'http://example.com'))
+      post :create, params: { donation: { price: 10 } }
+    end
+  end
+end

--- a/spec/system/custom_donation_system_spec.rb
+++ b/spec/system/custom_donation_system_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Custom donation system', type: :system, js: true do
+  before do
+    visit donate_path
+  end
+
+  describe 'user inputs custom donation amount' do
+    context 'user inputs an integer' do
+      it 'updates donate button text entered amount' do
+        find('#other').click
+        fill_in('Other', with: '40')
+        expect(page).to have_button('Donate $40')
+      end
+
+      it 'does not update button text if amount is 0' do
+        find('#other').click
+        fill_in('Other', with: '0')
+        expect(page).to have_button('Donate')
+      end
+
+      it 'opens a new window when donate button is clicked' do
+        allow(Stripe::Checkout::Session).to receive(:create).and_return(double(url: ''))
+        find('#other').click
+        fill_in('Other', with: '40')
+        click_on 'Donate $40'
+        expect(page.driver.browser.window_handles.size).to eq 2
+      end
+    end
+
+    context 'user inputs non-integer' do
+      it 'updates donate button to ask for a dollar amount' do
+        find('#other').click
+        fill_in('Other', with: 'not number')
+        expect(page).to have_button('Please enter a dollar amount')
+      end
+    end
+  end
+end


### PR DESCRIPTION
For issue #92. 

I'm a little unsure about how I set this up. I'm happy for feedback and to make changes. 

I ended up using the stripe gem to create a checkout session link with the amount entered in the input field, and added a message in case someone entered a non-dollar amount. Right now it accepts integers but not floats. I can change that if you want. 

When a fixed option is selected: 
<img width="511" alt="Screenshot 2024-02-01 at 1 22 50 PM" src="https://github.com/wnbrb/wnb-rb-site/assets/82609260/83b070a9-955a-4902-b65a-86f273d0fdad">

When the other amount is selected: 
<img width="537" alt="Screenshot 2024-02-01 at 1 22 58 PM" src="https://github.com/wnbrb/wnb-rb-site/assets/82609260/b28b16e2-ad98-4fff-b736-ab259fbbdeb4">

When the input is not an integer: 
<img width="616" alt="Screenshot 2024-01-31 at 2 03 11 PM" src="https://github.com/wnbrb/wnb-rb-site/assets/82609260/28b1addf-97ed-4de7-bd28-456f30de3047">

When the input is an integer:
<img width="613" alt="Screenshot 2024-01-31 at 2 03 25 PM" src="https://github.com/wnbrb/wnb-rb-site/assets/82609260/378355d0-3ec2-4de4-986d-7e2e544dab19">


