### PR TITLE
Temporarily remove the job board

### DIFF
--- a/app/javascript/components/layout/Footer.jsx
+++ b/app/javascript/components/layout/Footer.jsx
@@ -42,9 +42,6 @@ const Footer = () => (
                 </div>
                 <div className="footer-col">
                     <p className="footer-col-item footer-col-title">Resources</p>
-                    <a className="footer-col-item" href="/jobs">
-                        Job Board
-                    </a>
                     <a className="footer-col-item" href="/meetups">
                         Meetups
                     </a>

--- a/app/javascript/components/layout/Header.jsx
+++ b/app/javascript/components/layout/Header.jsx
@@ -7,7 +7,6 @@ import 'stylesheets/header.scss';
 
 const Header = () => {
     const links = [
-        { id: 1, text: 'Job Board', href: '/jobs' },
         { id: 2, text: 'Meetups', href: '/meetups' },
         { id: 3, text: 'Partner with Us', href: '/partner-with-us' },
     ];

--- a/app/javascript/stylesheets/header.scss
+++ b/app/javascript/stylesheets/header.scss
@@ -18,7 +18,7 @@ header {
             }
 
             nav.nav {
-                @apply hidden md:w-full md:flex md:justify-between;
+                @apply hidden md:w-full md:flex md:justify-between ml-5;
 
                 .menu {
                     @apply md:w-full md:self-center;
@@ -27,7 +27,7 @@ header {
                         @apply flex flex-row justify-around lg:justify-start;
 
                         li {
-                            @apply lg:px-10;
+                            @apply lg:px-5;
                             a {
                                 @apply text-gray-600 text-base font-normal leading-5 transition-all cursor-pointer hover:underline md:hover:no-underline;
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,6 @@ Rails.application.routes.draw do
 
   get '/partner-with-us', to: 'site#sponsor_us'
   get '/meetups', to: 'site#meetups'
-  get '/jobs', to: 'site#jobs'
-  get '/jobs/authenticate', to: 'site#jobs_authenticate'
   get '/join-us', to: 'site#join_us'
   get '/donate', to: 'site#donate'
   get '/meetups/:year/:month/:day', to: 'site#past_meetup'

--- a/spec/system/visit_site_pages_spec.rb
+++ b/spec/system/visit_site_pages_spec.rb
@@ -16,19 +16,6 @@ RSpec.describe 'User visit site pages', type: :system, js: true do
     visit sponsor_us_path
     expect(page).to have_text('Partner with Us')
   end
-  it 'visits jobs page' do
-    visit jobs_path
-
-    expect(page).to have_text('The WNB.rb job board is password protected')
-    expect(page).to have_current_path(jobs_authenticate_path)
-    expect(page).to have_button('View Job Board')
-
-    fill_in 'password', with: 'testing'
-
-    click_on 'View Job Board'
-
-    expect(page).to have_text('Jobs')
-  end
 
   it 'visits join_us page' do
     visit join_us_path


### PR DESCRIPTION
We are revamping our jobs program. In the meantime, I think we should remove our now-defunct jobs page in order not to confuse people.

This PR removes the routes to the job board and links in the menu and footer. I've kept all the underlying code (models, controllers, views) because I think we'll do something else with them, but I'll remove them if not.