### PR TITLE
Builds yarn assets as part of setup commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 setup:
-	bundle install && yarn install && rails db:setup
+	bundle install && yarn install && yarn build && yarn build:css && rails db:setup
 
 start:
 	foreman start


### PR DESCRIPTION
This commit adds two commands to the `setup` target:
- `yarn build`
- `yarn build:css`

This ensures that RSpec runs pass on an initial setup of the WNB project if the project hasn't been run yet (ex: via foreman)