### PR TITLE
Add new "Sponsor Us" page

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -12,4 +12,6 @@ class SiteController < ApplicationController
   def jobs_authenticate; end
 
   def past_meetup; end
+
+  def sponsor_us; end
 end

--- a/app/javascript/components/layout/Footer.jsx
+++ b/app/javascript/components/layout/Footer.jsx
@@ -14,10 +14,10 @@ const Footer = () => (
                     <a className="footer-col-item" href="/join-us">
                         Join WNB.rb
                     </a>
-                    <a className="footer-col-item" href="mailto:organizers@wnb-rb.dev">
-                        Contact the Organizers
+                    <a className="footer-col-item" href="/sponsor-us">
+                        Sponsor Us
                     </a>
-                    <a className="footer-col-item" href="/donate">
+                    <a className="footer-col-item" href="https://buy.stripe.com/6oE7t874ReRc7gA9AN">
                         Donate
                     </a>
                 </div>

--- a/app/javascript/components/layout/Header.jsx
+++ b/app/javascript/components/layout/Header.jsx
@@ -6,7 +6,10 @@ import Button from 'components/Button';
 import 'stylesheets/header.scss';
 
 const Header = () => {
-    const links = [{ id: 1, text: 'Meetups', href: '/meetups' }];
+    const links = [
+        { id: 1, text: 'Meetups', href: '/meetups' },
+        { id: 2, text: 'Donate', href: 'https://buy.stripe.com/6oE7t874ReRc7gA9AN' },
+    ];
 
     const [headerState, setHeaderState] = useState({
         className: '',
@@ -70,9 +73,9 @@ const Header = () => {
                             </ul>
                         </div>
                         <div className="user">
-                            <div className="donate">
-                                <a href="https://buy.stripe.com/6oE7t874ReRc7gA9AN">
-                                    <Button type="white-and-orange">Donate</Button>
+                            <div className="sponsor-us">
+                                <a href="/sponsor-us">
+                                    <Button type="white-and-orange">Sponsor Us</Button>
                                 </a>
                             </div>
                             <div className="join-us">

--- a/app/javascript/components/pages/SponsorUs.jsx
+++ b/app/javascript/components/pages/SponsorUs.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import SharedLayout from 'components/layout/SharedLayout';
+import PageTitleWithContainer from 'components/PageTitleWithContainer';
+
+const SponsorUs = () => (
+    <>
+        <Helmet>
+            <title>Sponsor Us | WNB.rb</title>
+        </Helmet>
+
+        <SharedLayout>
+            <PageTitleWithContainer text="Sponsor Us" />
+            <div className="-mt-8">
+                <stripe-pricing-table
+                    pricing-table-id="prctbl_1PSlcMBHbLqUjvnWol3sB6vA"
+                    publishable-key="pk_live_51JmdS1BHbLqUjvnWRLnx9KBZtHWLWHe67N3OpsV0FERko2K4lAZ6oyEo4pIq84YIMQPUJ8K1FY1UevXjZZPsiloq00EYai7JBQ"
+                />
+            </div>
+        </SharedLayout>
+    </>
+);
+
+export default SponsorUs;

--- a/app/javascript/packs/sponsor_us.jsx
+++ b/app/javascript/packs/sponsor_us.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
+import SponsorUs from 'components/pages/SponsorUs';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('root');
+    const root = createRoot(container);
+
+    root.render(
+        <HelmetProvider>
+            <SponsorUs />
+        </HelmetProvider>,
+    );
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700;900&display=swap" rel="stylesheet">
+    <script async src="https://js.stripe.com/v3/pricing-table.js"></script>
     <%- if ENV['GA_ID'] != "YOUR-GOOGLE-ANALYTICS-ID-HERE" %>
       <%= render partial: 'layouts/google_analytics' %>
     <% end %>

--- a/app/views/site/sponsor_us.html.erb
+++ b/app/views/site/sponsor_us.html.erb
@@ -1,0 +1,2 @@
+<%= append_javascript_pack_tag "sponsor_us" %>
+<%= append_stylesheet_pack_tag "sponsor_us" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
 
   get '/meetups', to: 'site#meetups'
   get '/join-us', to: 'site#join_us'
+  get '/sponsor-us', to: 'site#sponsor_us'
   get '/meetups/:year/:month/:day', to: 'site#past_meetup'
 
   root 'site#home'


### PR DESCRIPTION
This PR adds a sponsorship section back to our website with a pricing table generated by Stripe. It also modifies the header to make sponsoring the second call to action, while moving the "donate" button to the left side.

![screenshot_2024-06-17_at_4 52 56___pm_720](https://github.com/wnbrb/wnb-rb-site/assets/9601737/61482130-8a0f-4cc8-9622-0fef9bc42a29)