### PR TITLE
Added hiring and donation link to sponsorship page

### DIFF
--- a/app/javascript/components/pages/SponsorUs.jsx
+++ b/app/javascript/components/pages/SponsorUs.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import SharedLayout from 'components/layout/SharedLayout';
 import PageTitleWithContainer from 'components/PageTitleWithContainer';
+import Card from 'components/Card';
+import Button from 'components/Button';
 
 const SponsorUs = () => (
     <>
@@ -11,11 +13,54 @@ const SponsorUs = () => (
 
         <SharedLayout>
             <PageTitleWithContainer text="Sponsor Us" />
-            <div className="-mt-8">
-                <stripe-pricing-table
-                    pricing-table-id="prctbl_1PSlcMBHbLqUjvnWol3sB6vA"
-                    publishable-key="pk_live_51JmdS1BHbLqUjvnWRLnx9KBZtHWLWHe67N3OpsV0FERko2K4lAZ6oyEo4pIq84YIMQPUJ8K1FY1UevXjZZPsiloq00EYai7JBQ"
-                />
+            <div className="container flex flex-col mx-auto md:max-w-[50rem] lg:max-w-[60rem]">
+                <section className="sponsorship-options">
+                    <h2 className="text-2xl font-bold my-2">Sponsorship tiers</h2>
+
+                    <stripe-pricing-table
+                        pricing-table-id="prctbl_1PSlcMBHbLqUjvnWol3sB6vA"
+                        publishable-key="pk_live_51JmdS1BHbLqUjvnWRLnx9KBZtHWLWHe67N3OpsV0FERko2K4lAZ6oyEo4pIq84YIMQPUJ8K1FY1UevXjZZPsiloq00EYai7JBQ"
+                    />
+                </section>
+
+                <hr className="my-12 mx-48" />
+
+                <div className="flex flex-row justify-between items-center space-x-5 mb-12 mt-2">
+                    <Card className="max-w-[35rem] min-h-[17rem]">
+                        <h2 className="text-2xl font-bold mb-2">Hire from WNB.rb</h2>
+                        <p className="mb-8">
+                            Even if you aren&apos;t a sponsor, you can hire from our community by
+                            posting your open jobs on our job board.
+                        </p>
+                        <a
+                            href="https://buy.stripe.com/28o4gW9cZ7oKbwQ7sJ"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <Button type="primary" className="max-w-[8rem]">
+                                Post a job
+                            </Button>
+                        </a>
+                    </Card>
+
+                    <Card className="max-w-[30rem] min-h-[17rem]">
+                        <h2 className="text-2xl font-bold mb-2">Make a donation</h2>
+                        <p className="mb-8">
+                            Not ready to sponsor WNB.rb? That&apos;s okay! We&apos;d still greatly
+                            appreciate a donation of any amount. All the money we earn goes back
+                            into the community.
+                        </p>
+                        <a
+                            href="https://buy.stripe.com/aEU3cS3SF9wS0ScdR5"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <Button type="primary" className="max-w-[8rem] ">
+                                Donate
+                            </Button>
+                        </a>
+                    </Card>
+                </div>
             </div>
         </SharedLayout>
     </>

--- a/app/javascript/components/pages/SponsorUs.jsx
+++ b/app/javascript/components/pages/SponsorUs.jsx
@@ -13,22 +13,20 @@ const SponsorUs = () => (
 
         <SharedLayout>
             <PageTitleWithContainer text="Sponsor Us" />
-            <div className="container flex flex-col mx-auto md:max-w-[50rem] lg:max-w-[60rem]">
-                <section className="sponsorship-options">
-                    <h2 className="text-2xl font-bold my-2">Sponsorship tiers</h2>
+            <section className="container flex flex-col mx-auto md:max-w-[50rem] lg:max-w-[60rem] sponsorship-options">
+                <h2 className="px-10 text-2xl font-bold my-2">Sponsorship tiers</h2>
 
-                    <stripe-pricing-table
-                        pricing-table-id="prctbl_1PSlcMBHbLqUjvnWol3sB6vA"
-                        publishable-key="pk_live_51JmdS1BHbLqUjvnWRLnx9KBZtHWLWHe67N3OpsV0FERko2K4lAZ6oyEo4pIq84YIMQPUJ8K1FY1UevXjZZPsiloq00EYai7JBQ"
-                    />
-                </section>
+                <stripe-pricing-table
+                    pricing-table-id="prctbl_1PSlcMBHbLqUjvnWol3sB6vA"
+                    publishable-key="pk_live_51JmdS1BHbLqUjvnWRLnx9KBZtHWLWHe67N3OpsV0FERko2K4lAZ6oyEo4pIq84YIMQPUJ8K1FY1UevXjZZPsiloq00EYai7JBQ"
+                />
+            </section>
 
-                <hr className="my-12 mx-48" />
-
-                <div className="flex flex-row justify-between items-center space-x-5 mb-12 mt-2">
-                    <Card className="max-w-[35rem] min-h-[17rem]">
+            <section className="mt-12 lg:mt-28 bg-wnbrb-pink-light">
+                <div className="container mx-auto flex flex-col md:flex-row gap-8 xl:gap-16 py-20 px-10 lg:px-8 xl:px-12">
+                    <Card className="w-100 md:w-1/2 flex-1 flex flex-col">
                         <h2 className="text-2xl font-bold mb-2">Hire from WNB.rb</h2>
-                        <p className="mb-8">
+                        <p className="mb-8 grow">
                             Even if you aren&apos;t a sponsor, you can hire from our community by
                             posting your open jobs on our job board.
                         </p>
@@ -37,15 +35,15 @@ const SponsorUs = () => (
                             target="_blank"
                             rel="noopener noreferrer"
                         >
-                            <Button type="primary" className="max-w-[8rem]">
+                            <Button type="primary" className="max-w-[8rem] ">
                                 Post a job
                             </Button>
                         </a>
                     </Card>
 
-                    <Card className="max-w-[30rem] min-h-[17rem]">
+                    <Card className="w-100 md:w-1/2 flex-1 flex flex-col">
                         <h2 className="text-2xl font-bold mb-2">Make a donation</h2>
-                        <p className="mb-8">
+                        <p className="mb-8 grow">
                             Not ready to sponsor WNB.rb? That&apos;s okay! We&apos;d still greatly
                             appreciate a donation of any amount. All the money we earn goes back
                             into the community.
@@ -61,7 +59,7 @@ const SponsorUs = () => (
                         </a>
                     </Card>
                 </div>
-            </div>
+            </section>
         </SharedLayout>
     </>
 );


### PR DESCRIPTION
This PR adds links for sponsors to pay us for posting a job in our Slack or just making a corporate donation.

<img width="1079" alt="Screenshot 2024-06-21 at 10 39 25 AM" src="https://github.com/wnbrb/wnb-rb-site/assets/9601737/83dfc4d8-4d55-4a3d-925d-e54b3de39715">

@luciagirasoles Please feel free to correct any of my React and styles here.