### PR TITLE
Add links to speaker in meetup page

### DIFF
--- a/app/javascript/components/pages/PastMeetup.jsx
+++ b/app/javascript/components/pages/PastMeetup.jsx
@@ -33,8 +33,93 @@ const SpeakerBiosBlock = ({ speakers }) => {
                 <h4 className="text-xl font-bold text-gray md:text-2xl">About the speakers</h4>
             </div>
             <div className="flex flex-wrap items-center gap-5">
-                {speakers?.map(({ id, bio }) => (
-                    <div key={id}>{bio}</div>
+                {speakers?.map(({ id, bio, name, links }) => (
+                    <div key={id}>
+                        <div>{bio}</div>
+                        {Object.keys(links).length > 0 && (
+                            <div className="flex items-center">
+                                <p className="mr-3">More from {name}:</p>
+                                {links.twitter && (
+                                    <a
+                                        href={links.twitter}
+                                        aria-label="Twitter"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <i
+                                            className="bi bi-twitter-x social-icon h-4 w-4 fill-current mx-1"
+                                            style={{ width: '15px' }}
+                                        />
+                                    </a>
+                                )}
+                                {links.github && (
+                                    <a
+                                        href={links.github}
+                                        aria-label="Github"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <i
+                                            className="bi bi-github social-icon h-4 w-4 fill-current mx-1"
+                                            style={{ width: '15px' }}
+                                        />
+                                    </a>
+                                )}
+                                {links.linkedin && (
+                                    <a
+                                        href={links.linkedin}
+                                        aria-label="Linkedin"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <i
+                                            className="bi bi-linkedin social-icon h-4 w-4 fill-current mx-1"
+                                            style={{ width: '15px' }}
+                                        />
+                                    </a>
+                                )}
+                                {links.mastodon && (
+                                    <a
+                                        href={links.mastodon}
+                                        aria-label="Mastodon"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <i
+                                            className="bi bi-mastodon social-icon h-4 w-4 fill-current"
+                                            style={{ width: '15px' }}
+                                        ></i>
+                                    </a>
+                                )}
+                                {links.website && (
+                                    <a
+                                        href={links.website}
+                                        aria-label="Website"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <i
+                                            className="bi bi-globe social-icon h-4 w-4 fill-current"
+                                            style={{ width: '15px' }}
+                                        />
+                                    </a>
+                                )}
+                                {links.other && (
+                                    <a
+                                        href={links.other}
+                                        aria-label="Other"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <i
+                                            className="bi bi-link-45deg social-icon h-4 w-4 fill-current mx-1"
+                                            style={{ width: '15px' }}
+                                        />
+                                    </a>
+                                )}
+                            </div>
+                        )}
+                    </div>
                 ))}
             </div>
         </div>

--- a/spec/system/visit_site_pages_spec.rb
+++ b/spec/system/visit_site_pages_spec.rb
@@ -31,31 +31,26 @@ RSpec.describe 'User visit site pages', type: :system, js: true do
   end
 
   it 'visits past meetup and displays speaker with valid links' do
-    meetup = create(:event, date: Date.new(2024, 2, 17), title: "Meetup February 2024")
+    meetup = create(:event, date: Date.new(2024, 2, 17), title: 'Meetup February 2024')
     speaker = create(:speaker, :with_valid_links)
-    speaker2 = create(:speaker, links: { github: "https://github.com/speaker2",
-                                        twitter: "https://twitter.com/speaker2",
-                                        mastodon: Faker::Internet.url,
-                                        other: Faker::Internet.url,
-                                        website: Faker::Internet.url,
-                                        linkedin: Faker::Internet.url  })
-    talk = create(:talk, speaker: speaker, event: meetup)
-    talk2 = create(:talk, speaker: speaker2, event: meetup)
+    speaker2 = create(:speaker, :with_valid_links, links: {mastodon: Faker::Internet.url})
+    create(:talk, speaker: speaker, event: meetup)
+    create(:talk, speaker: speaker2, event: meetup)
 
     visit "/meetups/#{meetup.date.year}/#{meetup.date.month}/#{meetup.date.day}"
 
-    expect(page).to have_link(href: "#{speaker2.links["mastodon"]}", exact: true)
+    expect(page).to have_link(href: speaker2.links['mastodon'].to_s, exact: true)
     expect(meetup.speakers.count).to eq(2)
   end
 
   it 'visits past meetup and displays available valid links speaker only' do
-    meetup = create(:event, date: Date.new(2024, 2, 17), title: "Meetup February 2024")
+    meetup = create(:event, date: Date.new(2024, 2, 17), title: 'Meetup February 2024')
     speaker = create(:speaker, links: { mastodon: Faker::Internet.url })
-    talk = create(:talk, speaker: speaker, event: meetup)
+    create(:talk, speaker: speaker, event: meetup)
 
     visit "/meetups/#{meetup.date.year}/#{meetup.date.month}/#{meetup.date.day}"
 
-    expect(page).not_to have_link(href: "#{speaker.links["twitter"]}", exact: true)
+    expect(page).not_to have_link(href: speaker.links['twitter'].to_s, exact: true)
     expect(meetup.speakers.count).to eq(1)
   end
 

--- a/spec/system/visit_site_pages_spec.rb
+++ b/spec/system/visit_site_pages_spec.rb
@@ -30,6 +30,35 @@ RSpec.describe 'User visit site pages', type: :system, js: true do
     expect(page).to have_text(meetup.title)
   end
 
+  it 'visits past meetup and displays speaker with valid links' do
+    meetup = create(:event, date: Date.new(2024, 2, 17), title: "Meetup February 2024")
+    speaker = create(:speaker, :with_valid_links)
+    speaker2 = create(:speaker, links: { github: "https://github.com/speaker2",
+                                        twitter: "https://twitter.com/speaker2",
+                                        mastodon: Faker::Internet.url,
+                                        other: Faker::Internet.url,
+                                        website: Faker::Internet.url,
+                                        linkedin: Faker::Internet.url  })
+    talk = create(:talk, speaker: speaker, event: meetup)
+    talk2 = create(:talk, speaker: speaker2, event: meetup)
+
+    visit "/meetups/#{meetup.date.year}/#{meetup.date.month}/#{meetup.date.day}"
+
+    expect(page).to have_link(href: "#{speaker2.links["mastodon"]}", exact: true)
+    expect(meetup.speakers.count).to eq(2)
+  end
+
+  it 'visits past meetup and displays available valid links speaker only' do
+    meetup = create(:event, date: Date.new(2024, 2, 17), title: "Meetup February 2024")
+    speaker = create(:speaker, links: { mastodon: Faker::Internet.url })
+    talk = create(:talk, speaker: speaker, event: meetup)
+
+    visit "/meetups/#{meetup.date.year}/#{meetup.date.month}/#{meetup.date.day}"
+
+    expect(page).not_to have_link(href: "#{speaker.links["twitter"]}", exact: true)
+    expect(meetup.speakers.count).to eq(1)
+  end
+
   context 'visit to unknown path' do
     before do
       method = Rails.application.method(:env_config)


### PR DESCRIPTION
modify the meetup page to display these links for each speaker if they are available, actually Im not really sure which icon should we use for "website" and "other", hence I use globe as website and link for other, need your feedback on this (the social media is based on speaker model), so it shows like this :

![image](https://github.com/user-attachments/assets/c7e3757d-8265-4cc3-a855-638d47dc3af3)

actually this PR changes kinda same one with https://github.com/wnbrb/wnb-rb-site/pull/227, but with some changes.

Look forward for the feedback.