### PR TITLE
Add erb-lint gem and configuration file for linting ERB files

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -1,0 +1,11 @@
+---
+EnableDefaultLinters: true
+linters:
+  ErbSafety:
+  enabled: true
+better_html_config: .better-html.yml
+Rubocop:
+  enabled: true
+rubocop_config:
+  inherit_from:
+  - .rubocop.yml

--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,8 @@ end
 # bug deprecate gems not longer in ruby standard warning
 gem 'drb', '~> 2.2.1'
 gem 'mutex_m', '~> 0.2.0'
+
+# add erb-lint gem
+gem 'erb_lint', require: false
+
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,13 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -121,6 +128,13 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
     drb (2.2.1)
+    erb_lint (0.8.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -377,6 +391,7 @@ GEM
       gli
       hashie
       websocket-driver
+    smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -430,6 +445,7 @@ DEPENDENCIES
   debug (~> 1.7.1)
   devise (~> 4.9.2)
   drb (~> 2.2.1)
+  erb_lint
   factory_bot_rails (~> 6.4.3)
   faker (~> 2.18.0)
   google_drive!

--- a/yarn.lock
+++ b/yarn.lock
@@ -6105,11 +6105,9 @@ mz@^2.7.0:
     thenify-all "^1.0.0"
 
 nanoid@^3.3.7:
-
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
-
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -7270,7 +7268,7 @@ react-is@^18.0.0:
 
 react-responsive@^10.0.0:
   version "10.0.0"
-  resolved "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-10.0.0.tgz#657c7a90823cd565f43aa5918bd8eb0cd2c91c91"
   integrity sha512-N6/UiRLGQyGUqrarhBZmrSmHi2FXSD++N5VbSKsBBvWfG0ZV7asvUBluSv5lSzdMyEVjzZ6Y8DL4OHABiztDOg==
   dependencies:
     hyphenate-style-name "^1.0.0"


### PR DESCRIPTION
- Added the `erb-lint` gem to the project for linting `.erb` files
- Created a `.erb_lint.yml` file with default linters enabled
- Verified the linter runs successfully on all `.erb` files

Resolves #175 

