### PR TITLE
Fix spacing issues in ERB files identified by erb-lint

### DIFF
--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -29,7 +29,7 @@
     <div class="row g-3" id="event_talks" data-controller="event-form-remove-talk">
       <div class="mx-auto col-8 order-last">
         <div class="card h-100 border-0 shadow-sm">
-          <%=button_tag type: "button", class: "btn btn-outline-primary fw-semibold h-100 p-3", data: { controller: "turbo", href: set_talk_admin_events_path(talk_id: "new_talk") } do %>
+          <%= button_tag type: "button", class: "btn btn-outline-primary fw-semibold h-100 p-3", data: { controller: "turbo", href: set_talk_admin_events_path(talk_id: "new_talk") } do %>
             <span class="rounded-2 h1 border border-1 border-primary mx-auto pb-0">
               <i class="bi bi-plus-lg"></i>
             </span>
@@ -45,7 +45,7 @@
     </div>
   </fieldset>
   <div class="actions text-center mb-4">
-    <%=f.submit "Save", class: "btn btn-primary btn-lg shadow-sm" %>
-    <%=link_to "Cancel", admin_events_path, class: "btn btn-outline-primary btn-lg shadow-sm" %>
+    <%= f.submit "Save", class: "btn btn-primary btn-lg shadow-sm" %>
+    <%= link_to "Cancel", admin_events_path, class: "btn btn-outline-primary btn-lg shadow-sm" %>
   </div>
 <% end %>

--- a/app/views/admin/events/form/_card_talk.html.erb
+++ b/app/views/admin/events/form/_card_talk.html.erb
@@ -16,7 +16,7 @@
         <div class="col-12">
           <div class="row g-2">
             <div class="col-auto">
-              <%=image_tag talk.speaker.image_url, class:"rounded-circle object-fit-cover border border-3 border-primary shadow", height: 53, width: 53, alt:"Profile photo for #{talk.speaker.name}" %>
+              <%= image_tag talk.speaker.image_url, class: "rounded-circle object-fit-cover border border-3 border-primary shadow", height: 53, width: 53, alt: "Profile photo for #{talk.speaker.name}" %>
             </div>
             <div class="col">
               <h2 class="card-title h6"><%= talk.talk_title %></h2>
@@ -35,7 +35,7 @@
               <small>
                 <% if talk.talk_video_link.present? %>
                   <span> Video: </span>
-                  <%= link_to "Youtube", talk.talk_video_link, class:"text-nowrap", target: "_blank", rel: "noopener noreferrer" %>
+                  <%= link_to "Youtube", talk.talk_video_link, class: "text-nowrap", target: "_blank", rel: "noopener noreferrer" %>
                 <% else %>
                   <span class="text-body-secondary fst-italic">(No video provided)</span>
                 <% end %>
@@ -45,7 +45,7 @@
               <%= button_tag type: :submit, formmethod: "get", formaction: set_talk_admin_events_path(talk_id: talk_id), class: "btn btn-info", data: { turbo_stream: "true" } do %>
                 <i class="bi bi-pencil-fill"></i>
               <% end %>
-              <%=button_tag type: "button", class: "btn btn-outline-secondary", data: { action: "event-form-remove-talk#removeRecord", talk_id: talk_id, persisted: talk.persisted? } do %>
+              <%= button_tag type: "button", class: "btn btn-outline-secondary", data: { action: "event-form-remove-talk#removeRecord", talk_id: talk_id, persisted: talk.persisted? } do %>
                 <i class="bi bi-trash3-fill"></i>
               <% end %>
             </div>
@@ -53,17 +53,17 @@
         </div>
       </div>
     </div>
-      <div class="card-footer bg-opacity-10 bg-primary">
-        <small class="<%=talk.updated_at ? 'text-body-secondary' : 'text-danger' %>">
-        <% if talk.updated_at%>
-          Last update <%=time_ago_in_words(talk.updated_at, include_seconds: true)%> ago
+    <div class="card-footer bg-opacity-10 bg-primary">
+      <small class="<%= talk.updated_at ? 'text-body-secondary' : 'text-danger' %>">
+        <% if talk.updated_at %>
+          Last update <%= time_ago_in_words(talk.updated_at, include_seconds: true) %> ago
         <% else %>
           Unsaved changes
         <% end %>
-        </small>
-      </div>
+      </small>
+    </div>
   </div>
 <% end %>
 <% if talk.persisted? %>
-  <input autocomplete="off" type="hidden" value="<%=talk_id%>" name="event[talks_attributes][<%=talk_id%>][id]" id="event_talks_attributes_<%=talk_id%>_id">
+  <input autocomplete="off" type="hidden" value="<%= talk_id %>" name="event[talks_attributes][<%= talk_id %>][id]" id="event_talks_attributes_<%= talk_id %>_id">
 <% end %>

--- a/app/views/admin/speakers/_form.html.erb
+++ b/app/views/admin/speakers/_form.html.erb
@@ -21,16 +21,16 @@
     <div class="accordion-item">
       <h2 class="accordion-header" id="headingLinks">
         <% accordion_button_class = speaker.links.compact_blank.present? ? "accordion-button" : "accordion-button collapsed" %>
-        <%= button_tag "Social media links", type: "button", class: accordion_button_class, data: { bs_toggle: "collapse", bs_target: "#collapseBody"} %>
+        <%= button_tag "Social media links", type: "button", class: accordion_button_class, data: { bs_toggle: "collapse", bs_target: "#collapseBody" } %>
       </h2>
       <% accordion_collapse_class = speaker.links.compact_blank.present? ? "accordion-collapse collapse show" : "accordion-collapse collapse" %>
-      <div id="collapseBody" class="<%= accordion_collapse_class %>" >
+      <div id="collapseBody" class="<%= accordion_collapse_class %>">
         <div class="accordion-body">
           <% Speaker::SOCIAL_MEDIA_LINKS.each do |link| %>
             <div class="mb-3">
               <div class="input-group">
                 <%= f.label link.to_sym, class: "input-group-text" %>
-                <%= f.text_field link.to_sym, class: "form-control shadow-sm", placeholder: "https://socialmedia.url", aria: { label: link.capitalize, describedby: link  } %>
+                <%= f.text_field link.to_sym, class: "form-control shadow-sm", placeholder: "https://socialmedia.url", aria: { label: link.capitalize, describedby: link } %>
               </div>
             </div>
           <% end %>
@@ -41,6 +41,6 @@
 
   <div class="actions text-center mb-4">
     <%= f.submit "Save", class: "btn btn-primary btn-lg" %>
-    <%=link_to "Cancel", admin_speakers_path, class: "btn btn-outline-primary btn-lg" %>
+    <%= link_to "Cancel", admin_speakers_path, class: "btn btn-outline-primary btn-lg" %>
   </div>
 <% end %>

--- a/app/views/admin/speakers/edit.html.erb
+++ b/app/views/admin/speakers/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col col-lg-6">
-      <h1>Edit speaker</h1>
-      <%=render 'form', speaker: @speaker %>
+    <h1>Edit speaker</h1>
+    <%= render 'form', speaker: @speaker %>
   </div>
 </div>

--- a/app/views/admin/speakers/index.html.erb
+++ b/app/views/admin/speakers/index.html.erb
@@ -27,36 +27,36 @@
       <table class="table table-sm text-center table-hover">
         <thead class="border-2">
         <tr class="table-info">
-            <th scope="col" class="p-3">Id</th>
-            <th scope="col" class="p-3">Name</th>
-            <th scope="col" class="p-3">Bio</th>
-            <th scope="col" class="p-3">Tagline</th>
-            <th scope="col" class="p-3">Image</th>
-            <th scope="col" class="p-3">Links</th>
-            <th scope="col" class="p-3">Actions</th>
+          <th scope="col" class="p-3">Id</th>
+          <th scope="col" class="p-3">Name</th>
+          <th scope="col" class="p-3">Bio</th>
+          <th scope="col" class="p-3">Tagline</th>
+          <th scope="col" class="p-3">Image</th>
+          <th scope="col" class="p-3">Links</th>
+          <th scope="col" class="p-3">Actions</th>
         </tr>
         </thead>
         <tbody>
 
-          <% @speakers.each do |speaker| %>
-            <tr class="border-2">
-              <td class="p-3 align-middle"><%= speaker.id %></td>
-              <td class="p-3 align-middle"><%= speaker.name %></td>
-              <td class="p-3 align-middle text-start"><%= truncate_html(speaker.bio, length: 70) %></td>
-              <td class="p-3 align-middle"><%= speaker.tagline %></td>
-              <td class="p-3 align-middle">
-                <div class="imagen-container">
-                  <%=image_tag speaker.image_url, class:"rounded-circle object-fit-cover", height: 53, width: 53, alt:"Profile photo for #{speaker.name}" %>
-                </div>
-              </td>
-              <td class="p-3 align-middle">
-                <%= render "admin/speakers/index/speaker_links", speaker: speaker%>
-              </td>
-              <td class="p-3 align-middle">
+        <% @speakers.each do |speaker| %>
+          <tr class="border-2">
+            <td class="p-3 align-middle"><%= speaker.id %></td>
+            <td class="p-3 align-middle"><%= speaker.name %></td>
+            <td class="p-3 align-middle text-start"><%= truncate_html(speaker.bio, length: 70) %></td>
+            <td class="p-3 align-middle"><%= speaker.tagline %></td>
+            <td class="p-3 align-middle">
+              <div class="imagen-container">
+                <%= image_tag speaker.image_url, class: "rounded-circle object-fit-cover", height: 53, width: 53, alt: "Profile photo for #{speaker.name}" %>
+              </div>
+            </td>
+            <td class="p-3 align-middle">
+              <%= render "admin/speakers/index/speaker_links", speaker: speaker %>
+            </td>
+            <td class="p-3 align-middle">
               <%= link_to "Edit", edit_admin_speaker_path(speaker) %>
             </td>
-            </tr>
-          <% end %>
+          </tr>
+        <% end %>
         </tbody>
       </table>
     </div>

--- a/app/views/admin/speakers/index/_speaker_links.html.erb
+++ b/app/views/admin/speakers/index/_speaker_links.html.erb
@@ -20,6 +20,3 @@
     <i class="bi bi-link-45deg" alt="other social link" title="other social link"></i>
   <% end %>
 <% end %>
-
-
-

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<div class= "flex flex-col justify-center items-center px-4">
+<div class="flex flex-col justify-center items-center px-4">
   <%= image_tag "logo.svg", class: "w-16 h-16 md:w-32 md:h-32 mx-auto", alt: "WNB.rb" %>
   <h1 class="text-lg md:text-3xl font-bold mb-8 text-center mt-2">Change your password</h1>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<div class= "flex flex-col justify-center items-center px-4">
+<div class="flex flex-col justify-center items-center px-4">
   <%= image_tag "logo.svg", class: "w-16 h-16 md:w-32 md:h-32 mx-auto", alt: "WNB.rb" %>
   <h1 class="text-lg md:text-3xl font-bold mb-8 text-center mt-2">Forgot your password?</h1>
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class:"mb-12" }) do |f| %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<div class= "flex flex-col justify-center items-center px-4">
+<div class="flex flex-col justify-center items-center px-4">
   <%= image_tag "logo.svg", class: "w-16 h-16 md:w-32 md:h-32 mx-auto", alt: "WNB.rb" %>
   <h1 class="text-lg md:text-3xl font-bold mb-8 text-center mt-2">Edit <%= resource_name.to_s.humanize %></h1>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<div class= "flex flex-col justify-center items-center px-4">
+<div class="flex flex-col justify-center items-center px-4">
   <%= image_tag "logo.svg", class: "w-16 h-16 md:w-32 md:h-32 mx-auto", alt: "WNB.rb" %>
   <h1 class="text-2xl md:text-4xl font-bold text-center mt-2 mb-8">Sign up</h1>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -6,7 +6,7 @@
   </ul>
 <% end %>
 
-<div class= "flex flex-col justify-center items-center px-4">
+<div class="flex flex-col justify-center items-center px-4">
   <%= image_tag "logo.svg", class: "w-16 h-16 md:w-32 md:h-32 mx-auto", alt: "WNB.rb" %>
   <h1 class="text-2xl md:text-4xl font-bold text-center mt-2 mb-8">Welcome</h1>
   <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "mb-12" }) do |f| %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8"/>
+    <meta charset="UTF-8">
     <title>WNB.rb: A Virtual Community for Women and Non-Binary Rubyists - Admin</title>
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="ahrefs-site-verification" content="278d483f145fb715ab32bcaee341408d07e8705b743354e9dac0e2ec8da33e29">
-    <link href="<%= canonical_url %>" hreflang="en-us" rel="alternate"/>
-    <link href="<%= canonical_url %>" rel="canonical"/>
+    <link href="<%= canonical_url %>" hreflang="en-us" rel="alternate">
+    <link href="<%= canonical_url %>" rel="canonical">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700;900&display=swap" rel="stylesheet">

--- a/app/views/site/join_us.html.erb
+++ b/app/views/site/join_us.html.erb
@@ -2,6 +2,6 @@
 <%= append_stylesheet_pack_tag 'join_us' %>
 <%- if ENV.fetch('RECAPTCHA_ENABLED', nil) == 'true' %>
   <script>
-    var gtoken= '<%=raw(ENV.fetch('RECAPTCHA_SITE_KEY', nil))%>'
+    var gtoken= '<%= raw(ENV.fetch('RECAPTCHA_SITE_KEY', nil)) %>'
   </script>
 <% end -%>


### PR DESCRIPTION
This PR addresses formatting issues identified after implementing the ERB linter in [PR #264 - Add erb-lint gem and configuration file for linting ERB files](https://github.com/wnbrb/wnb-rb-site/pull/264), which was introduced to address [Issue #175 - Add lint for erb files](https://github.com/wnbrb/wnb-rb-site/issues/175).

This fix adjusted spacing by adding or removing spaces after code to comply with linter rules

**Before (lack of  space before `%>)**
![Screenshot 2025-02-04 114451](https://github.com/user-attachments/assets/6aa7d8c3-4f6c-4b57-b0f7-245526c9f73b)


**After ( space added)**
![Screenshot 2025-02-04 114515](https://github.com/user-attachments/assets/ca917058-906d-4a1d-b06f-420af7f14d90)
