### PR TITLE
Fix void element issues from running erb-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ google-credentials.json
 
 # Ignore asdf version file
 .tool-versions
+
+# Ignore erb-linting binary files
+bin/erb-lint
+bin/erb_lint
+bin/erblint
+

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -4,7 +4,7 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %><br>
     <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
   </div>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -7,15 +7,15 @@
     <%= f.hidden_field :reset_password_token %>
 
     <div class="field mb-4">
-      <%= f.label :password, "New password" %><br />
+      <%= f.label :password, "New password" %><br>
       <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+        <em>(<%= @minimum_password_length %> characters minimum)</em><br>
       <% end %>
       <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 
     <div class="field mb-4">
-      <%= f.label :password_confirmation, "Confirm new password" %><br />
+      <%= f.label :password_confirmation, "Confirm new password" %><br>
       <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -4,7 +4,7 @@
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class:"mb-12" }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
     <div class="field mb-4">
-      <%= f.label :email %><br />
+      <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,7 +6,7 @@
     <%= render "devise/shared/error_messages", resource: resource %>
 
     <div class="field mb-4">
-      <%= f.label :email %><br />
+      <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 
@@ -15,21 +15,21 @@
     <% end %>
 
     <div class="field mb-4">
-      <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+      <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br>
       <%= f.password_field :password, autocomplete: "new-password", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
       <% if @minimum_password_length %>
-        <br />
+        <br>
         <em><%= @minimum_password_length %> characters minimum</em>
       <% end %>
     </div>
 
     <div class="field mb-4">
-      <%= f.label :password_confirmation %><br />
+      <%= f.label :password_confirmation %><br>
       <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 
     <div class="field mb-4">
-      <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+      <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br>
       <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,12 +6,12 @@
     <%= render "devise/shared/error_messages", resource: resource %>
 
     <div class="field mb-4">
-      <%= f.label :name, 'Your Name' %><br />
+      <%= f.label :name, 'Your Name' %><br>
       <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 
     <div class="field mb-4">
-      <%= f.label :email %><br />
+      <%= f.label :email %><br>
       <%= f.email_field :email, autocomplete: "email", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 
@@ -19,12 +19,12 @@
       <%= f.label :password %>
       <% if @minimum_password_length %>
       <em>(<%= @minimum_password_length %> characters minimum)</em>
-      <% end %><br />
+      <% end %><br>
       <%= f.password_field :password, autocomplete: "new-password", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 
     <div class="field mb-4">
-      <%= f.label :password_confirmation %><br />
+      <%= f.label :password_confirmation %><br>
       <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-2 w-full shadow appearance-none border border-gray-400 border-opacity-60 outline-none rounded text-gray-700 leading-tight focus:border-transparent focus:ring-4 focus:ring-wnbrb-pink-default focus:ring-opacity-40" %>
     </div>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br />
+  <%= link_to "Log in", new_session_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br />
+  <%= link_to "Sign up", new_registration_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "underline whitespace-nowrap font-medium hover:text-red-400" %><br>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br>
   <% end %>
 <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -4,7 +4,7 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %><br>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,13 +2,13 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>WNB.rb: A Virtual Community for Women and Non-Binary Rubyists</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="ahrefs-site-verification" content="278d483f145fb715ab32bcaee341408d07e8705b743354e9dac0e2ec8da33e29">
-    <meta name="description" content="<%= meta_description %>" />
-    <link href="<%= canonical_url %>" hreflang="en-us" rel="alternate" />
-    <link href="<%= canonical_url %>" rel="canonical" />
+    <meta name="description" content="<%= meta_description %>">
+    <link href="<%= canonical_url %>" hreflang="en-us" rel="alternate">
+    <link href="<%= canonical_url %>" rel="canonical">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700;900&display=swap" rel="stylesheet">
@@ -28,7 +28,7 @@
 
 <body class=<%= body_class %>>
     <%= yield %>
-    <div id="root" class="min-w-full">
+    <div id="root" class="min-w-full"></div>
 </body>
 
 </html>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>


### PR DESCRIPTION
This PR addresses formatting issues identified after implementing the ERB linter in [PR #264 - Add erb-lint gem and configuration file for linting ERB files](https://github.com/wnbrb/wnb-rb-site/pull/264), which was introduced to address [Issue #175 - Add lint for erb files](https://github.com/wnbrb/wnb-rb-site/issues/175).

This fix removed '/'  in closing tag of void elements

Before
![Screenshot 2025-02-04 111247](https://github.com/user-attachments/assets/9806cdc4-5c72-44aa-b9a3-6df9ea0cf80e)

After
![Screenshot 2025-02-04 111226](https://github.com/user-attachments/assets/3ec2b9d1-4ccf-40cb-b3a3-782b679a46d2)
