### PR TITLE
change js tag to inline script

### DIFF
--- a/app/views/site/join_us.html.erb
+++ b/app/views/site/join_us.html.erb
@@ -1,7 +1,7 @@
 <%= append_javascript_pack_tag 'join_us' %>
 <%= append_stylesheet_pack_tag 'join_us' %>
 <%- if ENV.fetch('RECAPTCHA_ENABLED', nil) == 'true' %>
-  <%= javascript_tag do %>
+  <script>
     var gtoken= '<%=raw(ENV.fetch('RECAPTCHA_SITE_KEY', nil))%>'
-  <% end -%>
+  </script>
 <% end -%>


### PR DESCRIPTION
This PR addresses formatting issues identified after implementing the ERB linter in https://github.com/wnbrb/wnb-rb-site/pull/264, which was introduced to address https://github.com/wnbrb/wnb-rb-site/issues/175.

This fix replaces the js_tag with an inline script tag
**Before**
![Screenshot 2025-02-11 120356](https://github.com/user-attachments/assets/a6db628b-bbda-49ca-b78a-d1645caa76a7)

**After**
![Screenshot 2025-02-11 120334](https://github.com/user-attachments/assets/1262f3e3-460c-4a17-87cb-e2bcad7dcb6e)
