### PR TITLE
add quotes to class attribute in <body> tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
 </head>
 <%- body_class = 'admin' if controller_name == 'sessions' %>
 
-<body class=<%= body_class %>>
+<body class='<%= body_class %>'>
     <%= yield %>
     <div id="root" class="min-w-full"></div>
 </body>


### PR DESCRIPTION
This PR addresses formatting issues identified after implementing the ERB linter in https://github.com/wnbrb/wnb-rb-site/pull/264, which was introduced to address https://github.com/wnbrb/wnb-rb-site/issues/175.

This fix added quotes around attribute value

Before

![Screenshot 2025-02-24 132359](https://github.com/user-attachments/assets/e663a0e8-848a-41a0-bc37-8c61841327e6)

After
![Screenshot 2025-02-24 132407](https://github.com/user-attachments/assets/467996ce-cb18-4964-9620-67b59e88c0b0)

