### PR TITLE
Remove ability for users to sign up for an account

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,6 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   validates :role, inclusion: { in: ROLES }, allow_nil: true
   devise :database_authenticatable,
-         :registerable,
          :recoverable,
          :rememberable,
          :validatable,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,7 @@ Rails.application.routes.draw do
   devise_for :users,
              path: 'admin',
              path_names: {
-               sign_in: '/',
-               sign_up: 'new',
-               registration: 'register',
+               sign_in: '/'
              }
 
   namespace :admin do


### PR DESCRIPTION
Partial Fix for [User without roles should not access to Admin dashboard](https://github.com/wnbrb/wnb-rb-site/issues/186)
This PR removes ':registerable' from User model devise config, and removes the now-unused paths to 'register' and 'sign-up' in devise_for :user in routes.rb. This change prevents users from creating new accounts and accessing the admin dashboard, ensuring only authorized users can log in.

**Next steps:** This is only a partial fix. Someone with production access needs to review and confirm which users have already created accounts and if they are admins, as they may currently have unintended access.


**Before**
![image](https://github.com/user-attachments/assets/40402653-b45e-45f9-bf40-2c0b6490ecb1)
![image](https://github.com/user-attachments/assets/83df6a2e-6d91-4e9f-abbe-e41be8770de4)

**After**
![image](https://github.com/user-attachments/assets/38ff5b3e-806b-453e-b68f-34c98aeab2e7)


![image](https://github.com/user-attachments/assets/de539170-f545-42bd-8f17-e738a5e62972)
