### PR TITLE
291 sort past meetups from most recent to oldest

### DIFF
--- a/app/javascript/components/meetups/EventsCalendar.jsx
+++ b/app/javascript/components/meetups/EventsCalendar.jsx
@@ -11,17 +11,18 @@ const EventsCalendar = () => {
     const [meetups, setMeetups] = useState([]);
     const [loading, setLoading] = useState(true);
     const calendarRef = useRef(null);
-
     useEffect(() => {
         const fetchData = async () => {
             const data = await getPastMeetups();
-            const flattenedMeetups = Object.entries(data).flatMap(([, meetupsByMonth]) => {
-                return Object.values(meetupsByMonth).flat();
-            });
+    
+            const flattenedMeetups = Object.entries(data)
+                .flatMap(([, meetupsByMonth]) => Object.values(meetupsByMonth).flat())
+                .sort((a, b) => new Date(b.date) - new Date(a.date)); 
+    
             setMeetups(flattenedMeetups);
             setLoading(false);
         };
-
+    
         fetchData();
     }, []);
 

--- a/app/javascript/components/meetups/EventsCalendar.jsx
+++ b/app/javascript/components/meetups/EventsCalendar.jsx
@@ -14,15 +14,15 @@ const EventsCalendar = () => {
     useEffect(() => {
         const fetchData = async () => {
             const data = await getPastMeetups();
-    
+
             const flattenedMeetups = Object.entries(data)
                 .flatMap(([, meetupsByMonth]) => Object.values(meetupsByMonth).flat())
-                .sort((a, b) => new Date(b.date) - new Date(a.date)); 
-    
+                .sort((a, b) => new Date(b.date) - new Date(a.date));
+
             setMeetups(flattenedMeetups);
             setLoading(false);
         };
-    
+
         fetchData();
     }, []);
 

--- a/app/javascript/components/meetups/MeetUp.jsx
+++ b/app/javascript/components/meetups/MeetUp.jsx
@@ -4,9 +4,7 @@ import meetup from '../../../assets/images/meetup.jpg';
 import Button from '../../components/Button';
 
 const Meetup = ({ speakers, title = '', talks, year, month, day }) => {
-    const sortedTalks = [...talks].sort((a, b) => new Date(b.date) - new Date(a.date));
-
-    const eventWithSpeaker = sortedTalks.map((talk) => {
+    const eventWithSpeaker = talks.map((talk) => {
         const speaker = speakers.find((speak) => speak.id === talk.speaker_id);
         return { ...talk, speaker };
     });
@@ -45,7 +43,7 @@ const Meetup = ({ speakers, title = '', talks, year, month, day }) => {
                 </div>
 
                 <a href={`/meetups/${year}/${month}/${day}`}>
-                    <Button type="primary" className="view-btn">
+                    <Button type="secondary" className="view-btn">
                         View
                     </Button>
                 </a>

--- a/app/javascript/components/meetups/MeetUp.jsx
+++ b/app/javascript/components/meetups/MeetUp.jsx
@@ -43,7 +43,7 @@ const Meetup = ({ speakers, title = '', talks, year, month, day }) => {
                 </div>
 
                 <a href={`/meetups/${year}/${month}/${day}`}>
-                    <Button type="secondary" className="view-btn">
+                    <Button type="primary" className="view-btn">
                         View
                     </Button>
                 </a>

--- a/app/javascript/components/pages/Meetups.jsx
+++ b/app/javascript/components/pages/Meetups.jsx
@@ -22,8 +22,8 @@ const Meetups = () => {
         const fetchData = async () => {
             const data = await getPastMeetups();
             const flattenedMeetups = Object.entries(data)
-            .flatMap(([, meetupsByMonth]) => Object.values(meetupsByMonth).flat())
-            .sort((a, b) => new Date(b.date) - new Date(a.date)); 
+                .flatMap(([, meetupsByMonth]) => Object.values(meetupsByMonth).flat())
+                .sort((a, b) => new Date(b.date) - new Date(a.date));
 
             setMeetups(flattenedMeetups);
             setLoading(false);

--- a/app/javascript/components/pages/Meetups.jsx
+++ b/app/javascript/components/pages/Meetups.jsx
@@ -21,9 +21,9 @@ const Meetups = () => {
     useEffect(() => {
         const fetchData = async () => {
             const data = await getPastMeetups();
-            const flattenedMeetups = Object.entries(data).flatMap(([, meetupsByMonth]) => {
-                return Object.values(meetupsByMonth).flat();
-            });
+            const flattenedMeetups = Object.entries(data)
+            .flatMap(([, meetupsByMonth]) => Object.values(meetupsByMonth).flat())
+            .sort((a, b) => new Date(b.date) - new Date(a.date)); 
 
             setMeetups(flattenedMeetups);
             setLoading(false);


### PR DESCRIPTION
- Update the past meetup section to display the most recent meetups to the oldest in descending order.
- Update the cards in the calendar component to display the meetings in descending order.