### PR TITLE
298 update GitHub actions workflow from ubuntu 2004 to ubuntu 2204

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.3.4']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:10


### PR DESCRIPTION
### Migrate GitHub Actions from ubuntu-20.04 to ubuntu-22.04

### Updated the runs-on value to ubuntu-22.04 in:

- Deploy workflow
- Tests workflow

### Reason for Change
The ubuntu-20.04 runner was officially deprecated and retired by GitHub on April 15, 2025, causing workflows relying on it to fail. This migration ensures that our CI/CD pipelines remain functional and future-proof.