### PR TITLE
Graceful 404 Handling for JSON and Other Formats

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,11 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :render_unauthorized
 
   def render_not_found
-    render('not_found', status: :not_found)
+    respond_to do |format|
+    format.html { render('not_found', status: :not_found) }
+    format.json { render json: { error: 'Not Found' }, status: :not_found }
+    format.any  { head :not_found }
+   end
   end
 
   private

--- a/app/javascript/stylesheets/community.scss
+++ b/app/javascript/stylesheets/community.scss
@@ -169,6 +169,9 @@
 }
 
 .section-cards .info-card{
+   @media (min-width: 768px){
     height: 91%;
     width: 100%;
+    padding: 25px;
+   }
 }


### PR DESCRIPTION
**Summary:**

This PR updates the render_not_found method in ApplicationController to handle non-HTML request formats more gracefully. Previously, requests with Accept: application/json or other formats would raise a MissingTemplate error because the view only existed for HTML.

**How to Reproduce the Bug (Before This Fix)**
curl -H "Accept: application/json" http://localhost:3000/nonexistent
 => raises ActionView::MissingTemplate

**How to Verify the Fix**
curl -H "Accept: text/html" http://localhost:3000/nonexistent
=> React 404 page renders as expected

curl -H "Accept: application/json" http://localhost:3000/nonexistent
=> {"error": "Not Found"}

curl -H "Accept: application/xml" http://localhost:3000/nonexistent -i
 => HTTP 404 with no body


**Additional Fix:**
Also includes a minor CSS tweak to .info-card to scope styles to desktop screens only, preventing unintended effects on mobile layout.
