### PR TITLE
Bugfix: enhance Speaker URL validation with robust error handling and normalization

### DIFF
--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -22,12 +22,14 @@ RSpec.describe Api::EventsController, type: :controller do
       speaker =
         create(
           :speaker,
+          :stub_http_ok,
           name: 'Speaker Name',
           links: {
             twitter: 'http://example.com/twitter-link',
             mastodon: 'http://example.com/mastodon-link',
             website: 'http://example.com/personal-website-link',
           },
+
         )
       Talk.create(
         event: july_meetup,

--- a/spec/factories/speakers.rb
+++ b/spec/factories/speakers.rb
@@ -7,10 +7,7 @@ FactoryBot.define do
     image_url { Faker::Internet.url }
   end
 
-  after(:build) { |_speaker| allow(HTTParty).to receive(:get).and_return(double(code: 200)) }
-
   trait :with_invalid_links do
-    after(:build) { |_speaker| allow(HTTParty).to receive(:get).and_return(double(code: 401)) }
     links { { notwitter: 'not-a-link', twitter: Faker::Internet.url } }
   end
 
@@ -20,5 +17,12 @@ FactoryBot.define do
 
   trait :with_empty_links do
     links { {} }
+  end
+
+  trait :stub_http_ok do
+    after(:build) do |_speaker|
+      allow(HTTParty).to receive(:head).and_return(double(code: 200))
+      allow(HTTParty).to receive(:get).and_return(double(code: 200))
+    end
   end
 end

--- a/spec/system/visit_site_pages_spec.rb
+++ b/spec/system/visit_site_pages_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe 'User visit site pages', type: :system, js: true do
   before do
     stub_const('ENV', ENV.to_hash.merge('JOB_BOARD_PASSWORD' => 'testing'))
     stub_const('ENV', ENV.to_hash.merge('JWT_HMAC_SECRET' => 'testing1'))
+
+    allow(HTTParty).to receive(:head).and_return(double(code: 200))
+    allow(HTTParty).to receive(:get).and_return(double(code: 200))
   end
   it 'visits home page' do
     visit root_path
@@ -32,8 +35,8 @@ RSpec.describe 'User visit site pages', type: :system, js: true do
 
   it 'visits past meetup and displays speaker with valid links' do
     meetup = create(:event, date: Date.new(2024, 2, 17), title: 'Meetup February 2024')
-    speaker = create(:speaker, :with_valid_links)
-    speaker2 = create(:speaker, :with_valid_links, links: {mastodon: Faker::Internet.url})
+    speaker = create(:speaker, :with_valid_links, :stub_http_ok)
+    speaker2 = create(:speaker, :with_valid_links, :stub_http_ok, links: {mastodon: Faker::Internet.url})
     create(:talk, speaker: speaker, event: meetup)
     create(:talk, speaker: speaker2, event: meetup)
 
@@ -45,7 +48,7 @@ RSpec.describe 'User visit site pages', type: :system, js: true do
 
   it 'visits past meetup and displays available valid links speaker only' do
     meetup = create(:event, date: Date.new(2024, 2, 17), title: 'Meetup February 2024')
-    speaker = create(:speaker, links: { mastodon: Faker::Internet.url })
+    speaker = create(:speaker, :stub_http_ok, links: { mastodon: Faker::Internet.url })
     create(:talk, speaker: speaker, event: meetup)
 
     visit "/meetups/#{meetup.date.year}/#{meetup.date.month}/#{meetup.date.day}"


### PR DESCRIPTION
## Improve URL validation for Speaker social media links
  This PR improves the robustness of our speaker link validation while providing better feedback for invalid URLs.
### Changes

- Enhances URL validation logic in the Speaker model
- Adds proper error messages showing which social media link failed
- Implements URL normalization to handle links without schemes
- Adds timeout and better HTTP request handling
- Updates test suite with comprehensive URL validation scenarios

### Technical Improvements

- Uses HEAD requests first, falling back to GET for better performance
- Adds 4-second timeout to prevent hanging on dead links
- Accepts 2xx and 3xx responses as valid
- Normalizes URLs by adding https:// if no scheme present
- Improves error messages to show which social media link failed
- Adds proper HTTP request headers and redirect handling

### Test Suite Updates

- Adds comprehensive specs for URL validation scenarios
- Updates factories to use new :stub_http_ok trait
- Improves system tests to handle HTTP stubbing
- Adds tests for:
    - Blank URLs
    - URLs without schemes
    - HEAD/GET fallback
    - Redirect handling
    - Timeouts
    - Invalid responses

### Testing Instructions
  ``` 
  bundle exec rspec spec/models/speaker_spec.rb
  bundle exec rspec spec/system/visit_site_pages_spec.rb
  ```
