### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/wnbrb/wnb-rb-site/security/code-scanning/5](https://github.com/wnbrb/wnb-rb-site/security/code-scanning/5)

To fix the problem, we should add an explicit `permissions` block to the job configuration (inside the `build` job), or at the workflow root level—either approach will remediate the risk and follow recommended practice. Since the job is named `build` and performs a deploy to Heroku by pushing contents (but it does not, in the snippet provided, require write access to the GitHub repository's content), the least privilege currently required is likely just `contents: read`. If additional privileges are needed later (for example, updating pull requests or issues), those can be added in a granular way. The best place to add this block is just above `runs-on:` within the `build` job (within `.github/workflows/deploy.yml`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
