### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Tests
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/wnbrb/wnb-rb-site/security/code-scanning/6](https://github.com/wnbrb/wnb-rb-site/security/code-scanning/6)

The best way to fix this problem is to explicitly set the minimal required permissions for the workflow's use of the GITHUB_TOKEN. Since the job only checks out code and runs install/build/test commands, it does not need write access—`contents: read` suffices.  
To do this, add a `permissions:` block to the workflow. This can be at the workflow root (above the `jobs:` key), applying to all jobs, or directly under the individual job (`test:` in this case).  
For clarity and conciseness, it is recommended to set it at the workflow root level so all jobs inherit it (unless there are jobs requiring wider permissions, which is not the case here).  
This should be placed immediately after the workflow name and trigger definition, prior to jobs.

**Required change:**  
- Edit `.github/workflows/test.yml`
- Add the following block at line 3 (after `name:` and `on:`):  
  ```yaml
  permissions:
    contents: read
  ```

No imports, definitions, or extra code—just the explicit YAML permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
