### PR TITLE
Add controller tests

### DIFF
--- a/app/controllers/api/registrations_controller.rb
+++ b/app/controllers/api/registrations_controller.rb
@@ -2,7 +2,7 @@
 module Api
   class RegistrationsController < ApplicationController
     def register_user
-      return send_email if Rails.env.development?
+      return send_email if skip_recaptcha?
 
       if !params.key?(:gtoken)
         render json: { error: 'Recaptcha is disabled' }, status: :not_implemented
@@ -23,6 +23,10 @@ module Api
       DiscordInvitationMailer.invite(name, email, discord_link).deliver_now
 
       render json: { success: 'Captcha challenge is correctly solved' }, status: :ok
+    end
+
+    def skip_recaptcha?
+      ENV['SKIP_RECAPTCHA'] == 'true' || Rails.env.development?
     end
   end
 end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Admin::DashboardController, type: :controller do
+  let(:admin_user) { create(:user, :admin) }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe 'GET #show' do
+    let!(:events) { create_list(:event, 3) }
+    let!(:speakers) { create_list(:speaker, 5) }
+    let!(:users) { create_list(:user, 10) }
+
+    before { get :show }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the show template' do
+      expect(response).to render_template(:show)
+    end
+  end
+end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AdminController, type: :controller do
+  let(:admin_user) { create(:user, :admin) }
+  let(:regular_user) { create(:user) }
+
+  controller do
+    def test_access
+      render plain: 'Access granted'
+    end
+
+    def test_edit
+      authorize :anything, :edit?
+      render plain: 'Edit granted'
+    end
+  end
+
+  before do
+    routes.draw do
+      get 'test_access', to: 'admin#test_access'
+      get 'test_edit', to: 'admin#test_edit'
+    end
+  end
+
+  describe 'authentication' do
+    context 'when user is not signed in' do
+      it 'redirects to sign in page' do
+        get :test_access
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when regular user is signed in' do
+      before do
+        sign_in regular_user
+      end
+
+      it 'allows access to view pages' do
+        get :test_access
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq('Access granted')
+      end
+
+      it 'forbids access to edit operations' do
+        expect(controller).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
+
+        get :test_edit
+        expect(response).to have_http_status(:unauthorized)
+        expect(flash[:alert]).to eq('You are not allowed to perform this action')
+      end
+    end
+
+    context 'when admin user is signed in' do
+      before do
+        sign_in admin_user
+      end
+
+      it 'allows access to view pages' do
+        get :test_access
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'allows access to edit operations' do
+        expect(controller).to receive(:authorize).and_return(true)
+
+        get :test_edit
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq('Edit granted')
+      end
+    end
+  end
+end

--- a/spec/controllers/api/registrations_controller_spec.rb
+++ b/spec/controllers/api/registrations_controller_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Api::RegistrationsController, type: :controller do
+
+  describe 'POST #register_user' do
+    let(:valid_params) do
+      {
+        name: 'Test User',
+        email: 'test@example.com'
+      }
+    end
+
+    context 'when recaptcha is skipped' do
+      before do
+        allow(controller).to receive(:skip_recaptcha?).and_return(true)
+      end
+
+      it 'sends an email without recaptcha validation' do
+        expect(DiscordInvitationMailer).to receive(:invite).with(
+          valid_params[:name],
+          valid_params[:email],
+          anything
+        ).and_return(double(deliver_now: true))
+
+        post :register_user, params: valid_params, format: :json
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response['success']).to eq('Captcha challenge is correctly solved')
+      end
+    end
+
+    context 'when recaptcha is required' do
+      before do
+        allow(controller).to receive(:skip_recaptcha?).and_return(false)
+      end
+
+      context 'without recaptcha token' do
+        it 'returns not implemented status' do
+          post :register_user, params: valid_params, format: :json
+
+          expect(response).to have_http_status(:not_implemented)
+          json_response = JSON.parse(response.body)
+          expect(json_response['error']).to eq('Recaptcha is disabled')
+        end
+      end
+
+      context 'with valid recaptcha token' do
+        it 'sends email when recaptcha is valid' do
+          expect(controller).to receive(:validate_recaptcha).with('valid-token').and_return(true)
+          expect(DiscordInvitationMailer).to receive(:invite).with(
+            valid_params[:name],
+            valid_params[:email],
+            anything
+          ).and_return(double(deliver_now: true))
+
+          post :register_user, params: valid_params.merge(gtoken: 'valid-token'), format: :json
+
+          expect(response).to have_http_status(:ok)
+          json_response = JSON.parse(response.body)
+          expect(json_response['success']).to eq('Captcha challenge is correctly solved')
+        end
+      end
+
+      context 'with invalid recaptcha token' do
+        it 'returns error when recaptcha validation fails' do
+          expect(controller).to receive(:validate_recaptcha).with('invalid-token').and_return(false)
+
+          post :register_user, params: valid_params.merge(gtoken: 'invalid-token'), format: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          json_response = JSON.parse(response.body)
+          expect(json_response['error']).to eq('Error validating Recaptcha, Please try again later')
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    before_action :authenticate_user!, only: [:protected_action]
+
+    def index
+      render plain: 'test'
+    end
+
+    def protected_action
+      render plain: 'protected'
+    end
+  end
+
+  describe 'devise configuration' do
+    context 'when user signs up' do
+      before do
+        @request.env['devise.mapping'] = Devise.mappings[:user]
+      end
+
+      it 'calls configure_permitted_parameters before devise actions' do
+        sanitizer = double('sanitizer')
+        user_params = double('user_params')
+
+        allow(controller).to receive(:devise_parameter_sanitizer).and_return(sanitizer)
+
+        expect(sanitizer).to receive(:permit).with(:sign_up).and_yield(user_params)
+        expect(sanitizer).to receive(:permit).with(:sign_in).and_yield(user_params)
+        expect(sanitizer).to receive(:permit).with(:account_update).and_yield(user_params)
+
+        expect(user_params).to receive(:permit).with(:name, :email, :password, :password_confirmation, :remember_me)
+        expect(user_params).to receive(:permit).with(:email, :password, :remember_me)
+        expect(user_params).to receive(:permit).with(:name, :email, :password, :password_confirmation,
+:current_password)
+
+        controller.send(:configure_permitted_parameters)
+      end
+    end
+  end
+
+  describe '#configure_permitted_parameters' do
+    let(:sanitizer) { double('sanitizer') }
+    let(:user_params) { double('user_params') }
+
+    before do
+      allow(controller).to receive(:devise_parameter_sanitizer).and_return(sanitizer)
+    end
+
+    it 'permits correct parameters for sign up, sign in and account update' do
+
+      expect(sanitizer).to receive(:permit).with(:sign_up).and_yield(user_params)
+      expect(sanitizer).to receive(:permit).with(:sign_in).and_yield(user_params)
+      expect(sanitizer).to receive(:permit).with(:account_update).and_yield(user_params)
+
+      expect(user_params).to receive(:permit).with(:name, :email, :password, :password_confirmation, :remember_me)
+      expect(user_params).to receive(:permit).with(:email, :password, :remember_me)
+      expect(user_params).to receive(:permit).with(:name, :email, :password, :password_confirmation, :current_password)
+
+      controller.send(:configure_permitted_parameters)
+    end
+  end
+
+  describe '#validate_recaptcha' do
+    let(:token) { 'test_token' }
+
+    context 'when recaptcha is disabled' do
+      before do
+        allow(ENV).to receive(:fetch).with('RECAPTCHA_ENABLED', false).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(controller.send(:validate_recaptcha, token)).to be false
+      end
+    end
+
+    context 'when recaptcha is enabled' do
+      before do
+        allow(ENV).to receive(:fetch).with('RECAPTCHA_ENABLED', false).and_return(true)
+        allow(ENV).to receive(:fetch).with('RECAPTCHA_SECRET_KEY', nil).and_return('secret_key')
+      end
+
+      it 'makes request to Google recaptcha API' do
+
+        response = double('response')
+        allow(response).to receive(:code).and_return('200')
+        allow(response).to receive(:body).and_return('{"success": true, "score": 0.9}')
+
+        allow(Net::HTTP).to receive(:post_form).and_return(response)
+
+        result = controller.send(:validate_recaptcha, token)
+        expect(result).to be true
+      end
+
+      it 'returns false when score is too low' do
+        response = double('response')
+        allow(response).to receive(:code).and_return('200')
+        allow(response).to receive(:body).and_return('{"success": true, "score": 0.3}')
+
+        allow(Net::HTTP).to receive(:post_form).and_return(response)
+
+        result = controller.send(:validate_recaptcha, token)
+        expect(result).to be false
+      end
+    end
+  end
+
+  describe '#after_sign_in_path_for' do
+    context 'when user password has been changed' do
+      let(:user) { double('user', password_changed?: true) }
+
+      it 'redirects to admin dashboard' do
+        expect(controller.send(:after_sign_in_path_for, user)).to eq(admin_dashboard_path)
+      end
+    end
+
+    context 'when user password has not been changed' do
+      let(:user) { double('user', password_changed?: false) }
+
+      it 'redirects to edit registration path' do
+        expect(controller.send(:after_sign_in_path_for, user)).to eq(edit_user_registration_path)
+      end
+    end
+  end
+
+describe '#render_not_found' do
+  controller(ApplicationController) do
+    def html_test
+      render_not_found
+    end
+
+    def json_test
+      request.format = :json
+      render_not_found
+    end
+
+    def other_format_test
+      request.format = :xml
+      render_not_found
+    end
+  end
+
+  before do
+    routes.draw do
+      get 'html_test' => 'anonymous#html_test'
+      get 'json_test' => 'anonymous#json_test'
+      get 'other_format_test' => 'anonymous#other_format_test'
+    end
+  end
+
+  it 'renders not found template for HTML requests' do
+    get :html_test
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'renders JSON error for JSON requests' do
+    get :json_test
+    expect(response).to have_http_status(:not_found)
+    expect(JSON.parse(response.body)).to eq({ 'error' => 'Not Found' })
+  end
+
+  it 'returns not found status for other formats' do
+    get :other_format_test
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).to be_blank
+  end
+end
+
+  describe 'Pundit authorization' do
+    controller do
+      def unauthorized_action
+        raise Pundit::NotAuthorizedError
+      end
+    end
+
+    it 'rescues from Pundit::NotAuthorizedError' do
+      routes.draw { get 'unauthorized_action' => 'anonymous#unauthorized_action' }
+
+      expect do
+        get :unauthorized_action
+      end.not_to raise_error
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'authentication' do
+    before do
+      routes.draw do
+        get 'index' => 'anonymous#index'
+        get 'protected_action' => 'anonymous#protected_action'
+      end
+    end
+
+    context 'when accessing public actions' do
+      it 'allows access without authentication' do
+        get :index
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq('test')
+      end
+    end
+
+    context 'when accessing protected actions' do
+      it 'redirects to sign in when not authenticated' do
+        get :protected_action
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'allows access when authenticated' do
+        user = create(:user)
+        sign_in user
+
+        get :protected_action
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe 'current_user' do
+    context 'when user is signed in' do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it 'returns the current user' do
+        get :index
+        expect(controller.current_user).to eq(user)
+      end
+    end
+
+    context 'when user is not signed in' do
+      it 'returns nil' do
+        get :index
+        expect(controller.current_user).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/site_controller_spec.rb
+++ b/spec/controllers/site_controller_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SiteController, type: :controller do
+  describe 'GET #home' do
+    before { get :home }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the home template' do
+      expect(response).to render_template(:home)
+    end
+  end
+
+  describe 'GET #join_us' do
+    before { get :join_us }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the join_us template' do
+      expect(response).to render_template(:join_us)
+    end
+  end
+
+  describe 'GET #meetups' do
+    let!(:upcoming_events) { create_list(:event, 3, :upcoming) }
+
+    before { get :meetups }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the meetups template' do
+      expect(response).to render_template(:meetups)
+    end
+  end
+
+  describe 'GET #past_meetup' do
+  before { get :past_meetup, params: { year: '2023', month: '09', day: '15' } }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the past_meetup template' do
+      expect(response).to render_template(:past_meetup)
+    end
+  end
+
+  describe 'GET #sponsor_us' do
+    before { get :sponsor_us }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the sponsor_us template' do
+      expect(response).to render_template(:sponsor_us)
+    end
+  end
+
+  describe 'GET #community' do
+    before { get :community }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the community template' do
+      expect(response).to render_template(:community)
+    end
+  end
+end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Users::PasswordsController, type: :controller do
+  before do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  describe 'GET #new' do
+    before { get :new }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the new template' do
+      expect(response).to render_template(:new)
+    end
+
+    it 'assigns a new user' do
+      expect(assigns(:user)).to be_a_new(User)
+    end
+  end
+
+  describe 'POST #create' do
+    let(:user) { create(:user) }
+
+    context 'with valid email' do
+      before do
+        post :create, params: { user: { email: user.email } }
+      end
+
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'shows success message' do
+        expect(flash[:notice]).to be_present
+      end
+    end
+
+    context 'with invalid email' do
+      before do
+        post :create, params: { user: { email: 'invalid@example.com' } }
+      end
+
+      it 'renders new template' do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    let(:user) { create(:user) }
+    let(:reset_token) { user.send_reset_password_instructions }
+
+    before do
+      get :edit, params: { reset_password_token: reset_token }
+    end
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the edit template' do
+      expect(response).to render_template(:edit)
+    end
+  end
+end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Users::RegistrationsController, type: :controller do
+  before do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  describe 'GET #new' do
+    context 'when not signed in' do
+      before { get :new }
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'renders the new template' do
+        expect(response).to render_template(:new)
+      end
+
+      it 'assigns a new user' do
+        expect(assigns(:user)).to be_a_new(User)
+      end
+    end
+
+    context 'when already signed in' do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        get :new
+      end
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to(edit_user_registration_path)
+      end
+
+      it 'sets appropriate flash message' do
+        expect(flash[:alert]).to eq('You are already signed in.')
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    let(:valid_attributes) do
+      {
+        name: 'JohnDoe',
+        email: 'john@example.com',
+        password: 'password123',
+        password_confirmation: 'password123',
+        password_changed: true
+      }
+    end
+
+    context 'with valid parameters' do
+      it 'creates a new user' do
+        expect do
+          post :create, params: { user: valid_attributes }
+        end.to change(User, :count).by(1)
+      end
+
+      it 'signs in the user' do
+        post :create, params: { user: valid_attributes }
+        expect(controller.user_signed_in?).to be true
+      end
+
+      it 'redirects to root path' do
+        post :create, params: { user: valid_attributes }
+        expect(response).to redirect_to(edit_user_registration_path)
+      end
+    end
+
+    context 'with invalid parameters' do
+      before do
+        post :create, params: { user: { email: 'invalid' } }
+      end
+
+      it 'does not create a user' do
+        expect(User.count).to eq(0)
+      end
+
+      it 'renders new template' do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user
+      get :edit
+    end
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the edit template' do
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    context 'with valid parameters' do
+      before do
+        patch :update, params: {
+          user: {
+            name: 'Updated Name',
+            current_password: user.password
+          }
+        }
+      end
+
+      it 'updates the user' do
+        user.reload
+        expect(user.name).to eq('Updated Name')
+      end
+
+      it 'redirects to edit page' do
+        expect(response).to redirect_to(admin_dashboard_path)
+      end
+    end
+
+    context 'with invalid current password' do
+      before do
+        patch :update, params: {
+          user: {
+            name: 'Updated Name',
+            current_password: 'wrong_password'
+          }
+        }
+      end
+
+      it 'does not update the user' do
+        user.reload
+        expect(user.name).not_to eq('Updated Name')
+      end
+
+      it 'renders edit template' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -5,5 +5,13 @@ FactoryBot.define do
     sequence(:location) { |n| "Location #{n}" }
     sequence(:description) { |n| "Description #{n}" }
     date { 30.days.from_now }
+
+    trait :upcoming do
+      date { 1.week.from_now }
+    end
+
+    trait :past do
+      date { 1.week.ago }
+    end
   end
 end


### PR DESCRIPTION
This PR introduces a suite of controller tests to improve test coverage and ensure the reliability of key application functionality. The changes include:

New Controller Tests Added:

- **Admin Dashboard Controller**: Tests for the admin dashboard show action, verifying successful responses, template rendering, and data assignment.
- **Site Controller**: Tests for site-related actions to ensure proper handling of public-facing pages.
- **Admin Controller**: Tests for admin-specific functionality, including authentication and authorization checks.
- **Application Controller**: Tests for base application controller behaviors, such as error handling and common filters.
- **Registration Controller**: Tests for user registration flows, including form rendering and submission handling.
- **Passwords Controller**: Tests for password reset functionality, covering new, create, and edit actions with Devise integration.
- **Registrations API Controller**: Tests for API endpoints related to user registrations, ensuring proper JSON responses and error handling.