### PR TITLE
update bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'httparty', '~> 0.23.1'
 gem 'pagy', '~> 6.2'
 
 # timezones
-gem 'tzinfo-data', '~> 2.0',platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data', '~> 2.0', platforms: %i[windows jruby]
 
 # Explicitly depend on and compile nokogiri
 # so we can run CI on Ruby head
@@ -53,7 +53,7 @@ group :development, :test do
 
   # Call 'byebug' anywhere in the code to stop execution and get a
   # debugger console
-  gem 'byebug', '~> 11.1.3', platforms: %i[mri mingw x64_mingw]
+  gem 'byebug', '~> 11.1.3', platforms: %i[mri windows]
 
   # Generates fake data
   gem 'faker', '~> 2.18.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,23 +131,11 @@ GEM
       railties (>= 5.0.0)
     faker (2.18.0)
       i18n (>= 1.6, < 2)
-    faraday (2.11.0)
-      faraday-net_http (>= 2.0, < 3.4)
-      logger
-    faraday-mashify (0.1.1)
-      faraday (~> 2.0)
-      hashie
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (3.3.0)
-      net-http
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
-    gli (2.21.5)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashie (5.0.0)
     httparty (0.23.1)
       csv
       mini_mime (>= 1.0.0)
@@ -191,10 +179,7 @@ GEM
     msgpack (1.7.2)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
-    multipart-post (2.4.1)
     mutex_m (0.2.0)
-    net-http (0.4.1)
-      uri
     net-imap (0.4.20)
       date
       net-protocol
@@ -338,12 +323,6 @@ GEM
       semantic_range (>= 2.3.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-      faraday (>= 2.0)
-      faraday-mashify
-      faraday-multipart
-      gli
-      hashie
-      websocket-driver
     smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
@@ -366,7 +345,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
-    uri (0.13.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -434,4 +412,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.18
+   2.7.2


### PR DESCRIPTION
## Description

Updated `Gemfile` to replace deprecated platform declarations:

```ruby
gem 'tzinfo-data', '~> 2.0', platforms: %i[windows jruby]
gem 'byebug', '~> 11.1.3', platforms: %i[mri windows]
```
and regenerated Gemfile.lock to remove warnings like:
```
[DEPRECATED] Platform :mingw, :mswin, :x64_mingw is deprecated.
Please use platform :windows instead.
```
This eliminates the deprecation messages during bundle install.