### PR TITLE
Fix deprecation warnings when compile react pages style

### DIFF
--- a/app/javascript/react/packs/application.js
+++ b/app/javascript/react/packs/application.js
@@ -7,6 +7,7 @@
 import * as ActiveStorage from '@rails/activestorage';
 import 'channels';
 
+import '../stylesheets/tailwind.scss';
 import '../stylesheets/application.scss';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 

--- a/app/javascript/react/stylesheets/application.scss
+++ b/app/javascript/react/stylesheets/application.scss
@@ -1,7 +1,3 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
-
 body {
     @apply antialiased text-base;
     text-rendering: optimizeLegibility;

--- a/app/javascript/react/stylesheets/tailwind.scss
+++ b/app/javascript/react/stylesheets/tailwind.scss
@@ -1,0 +1,3 @@
+@use 'tailwindcss/base';
+@use 'tailwindcss/components';
+@use 'tailwindcss/utilities';

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "react-helmet-async": "^1.3.0",
         "react-responsive": "^10.0.0",
         "sass": "^1.60.0",
-        "sass-loader": "^13.2.0",
+        "sass-loader": "^16.0.5",
         "shakapacker": "8.0.2",
         "slim-select": "^2.9.2",
         "style-loader": "^3.3.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,8 @@
 module.exports = {
     plugins: {
+        'postcss-import': {},
         tailwindcss: {},
         autoprefixer: {},
-        'postcss-import': {},
         'postcss-flexbugs-fixes': {},
         'postcss-preset-env': {
             autoprefixer: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7879,10 +7879,10 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-loader@^13.2.0:
-  version "13.3.3"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.3.3.tgz#60df5e858788cffb1a3215e5b92e9cba61e7e133"
-  integrity sha512-mt5YN2F1MOZr3d/wBRcZxeFgwgkH44wVc2zohO2YF6JiOMkiXe4BYRZpSu2sO1g71mo/j16txzUhsKZlqjVGzA==
+sass-loader@^16.0.5:
+  version "16.0.5"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-16.0.5.tgz#257bc90119ade066851cafe7f2c3f3504c7cda98"
+  integrity sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==
   dependencies:
     neo-async "^2.6.2"
 


### PR DESCRIPTION
Deprecation The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.