### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

We have a lot of dependabot PRs that don't really need in-depth review because they bump patch or minor versions of our dependencies. Let's automate merging them so we have more time and energy for important website work :)

## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml` which auto-approves Dependabot PRs and enables auto-merge for patch and minor semver updates.
- Major version bumps still require manual review/merge.
- Relies on the repo's existing `allow_auto_merge` setting and branch protection (1 approval + passing status checks) — this workflow just supplies the approval automatically for eligible Dependabot PRs.

## Test plan
- [ ] Merge this PR
- [ ] Wait for the next Dependabot PR and confirm it gets auto-approved
- [ ] Confirm patch/minor PRs merge automatically once checks pass
- [ ] Confirm a major-version PR (if one appears) is left for manual review