### PR TITLE
fix: the jwt authentication uses env in jobs_controller.rb

### DIFF
--- a/app/controllers/api/jobs_controller.rb
+++ b/app/controllers/api/jobs_controller.rb
@@ -31,7 +31,7 @@ module Api
     end
 
     def hmac_secret
-      ENV.fetch('JWT_HMAC_SECRET', nil)
+      ENV.fetch('JWT_HMAC_SECRET')
     end
 
     def job_board_password


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `app/controllers/api/jobs_controller.rb`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `app/controllers/api/jobs_controller.rb:34` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 3-step |

**Description**: The JWT authentication uses ENV.fetch('JWT_HMAC_SECRET', nil) which allows nil fallback. When the environment variable is unset, JWT tokens are signed with nil/empty secret, allowing attackers to forge valid tokens using any secret or no signature at all.

## Evidence

**Exploitation scenario**: Attacker crafts a JWT token with any payload and signs it with empty string or arbitrary secret, then sends request to GET /api/jobs with forged token in Authorization header.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This API endpoint appears to be publicly accessible. This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `app/controllers/api/jobs_controller.rb`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
