### PR TITLE
Fix admin password reset to send from a Resend-verified sender

### DIFF
--- a/app/javascript/react/components/pages/Meetups.jsx
+++ b/app/javascript/react/components/pages/Meetups.jsx
@@ -48,7 +48,7 @@ const Meetups = () => {
                 <title>Meetups | WNB.rb</title>
             </Helmet>
             <EventsCalendar events={meetups} />
-            <img src={horizontal} className="line" alt="horizontal line" />
+            <img src={horizontal} className="line-meetup" alt="horizontal line" />
             <SharedLayout>
                 {loading ? (
                     <LoadingSpinner />

--- a/app/javascript/react/stylesheets/home.scss
+++ b/app/javascript/react/stylesheets/home.scss
@@ -121,6 +121,10 @@
 }
 .line {
     margin-top: -2.5rem;
+
+    @media (min-width: 1024px) {
+      margin-top: -2.7rem;
+    }
 }
 .line2 {
     margin-top: 0;

--- a/app/javascript/react/stylesheets/meetup.scss
+++ b/app/javascript/react/stylesheets/meetup.scss
@@ -116,7 +116,7 @@
 h3 {
     @apply font-bold text-xl text-wnbrb-blue-navy;
 }
-.line {
+.line-meetup {
     position: relative;
     margin-top: -1rem;
     @media (min-width: 640px) {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'womennonbinary.rb@gmail.com'
+ config.mailer_sender = ENV.fetch('MAILER_FROM_ADDRESS', 'WNB.rb <exec@wnb-rb.dev>')
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
**Issue**

After migrating email delivery from Gmail SMTP to Resend, admin password-reset emails were broken. Devise's config.mailer_sender was still hardcoded to a gmail.com address and Resend rejects any from on a domain its API key isn't authorized for ("This API key is not authorized to send emails from gmail.com").

**Solution**
I pointed Devise's mailer sender at MAILER_FROM_ADDRESS (the same Resend-verified env var used by ApplicationMailer for the Discord invitation), so all transactional email shares one verified sender:

`config.mailer_sender = ENV.fetch('MAILER_FROM_ADDRESS', 'WNB.rb <exec@wnb-rb.dev>')`

**Other Changes:**
- Adjusted the horizontal line positioning in home page so it matches figma design.
- Renamed horizontal line in the events page so we dont confuse it with the horizontal line in homepage.
